### PR TITLE
fix: queue dump: add description for event that triggered a task

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,7 @@ github.com/flant/shell-operator v1.0.0-beta.7.0.20200204141603-35d09bc20f2e/go.m
 github.com/flant/shell-operator v1.0.0-beta.7.0.20200205122403-6e83952fff37 h1:Y6BvwSvm36dlCa8ubTueY/TMXBxVTPdrBar0Vxv6jRc=
 github.com/flant/shell-operator v1.0.0-beta.7.0.20200205122403-6e83952fff37/go.mod h1:MzOl6SRoPyVKTcg3FAxiNLpxKgmNYNZmXu9MYqdkyRk=
 github.com/flant/shell-operator v1.0.0-beta.7.0.20200205180330-22622f8aa612/go.mod h1:MzOl6SRoPyVKTcg3FAxiNLpxKgmNYNZmXu9MYqdkyRk=
+github.com/flant/shell-operator v1.0.0-beta.7.0.20200206051355-7ed900348af8 h1:yT+DhLFArIhmzuGFIVRdJISuPwK/RDv9W39nNVErc1Q=
 github.com/flant/shell-operator v1.0.0-beta.7.0.20200206051355-7ed900348af8/go.mod h1:MzOl6SRoPyVKTcg3FAxiNLpxKgmNYNZmXu9MYqdkyRk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/task/module_hook_metadata.go
+++ b/pkg/task/module_hook_metadata.go
@@ -12,6 +12,7 @@ import (
 
 // HookMetadata is metadata for addon-operator tasks
 type HookMetadata struct {
+	EventDescription string // event name for informative queue dump
 	HookName string
 	ModuleName string
 	BindingType BindingType
@@ -41,12 +42,18 @@ func HookMetadataAccessor(t task.Task) (meta HookMetadata) {
 func (hm HookMetadata) GetDescription() string {
 	if hm.ModuleName == "" {
 		// global hook
-		return fmt.Sprintf("%s:%s", string(hm.BindingType), hm.HookName)
+		return fmt.Sprintf("%s:%s:%s", string(hm.BindingType), hm.HookName, hm.EventDescription)
 	} else {
-		osh := ""
-		if hm.OnStartupHooks {
-			osh = ":onStartupHooks"
+		if hm.HookName == "" {
+			// module run
+			osh := ""
+			if hm.OnStartupHooks {
+				osh = ":onStartupHooks"
+			}
+			return fmt.Sprintf("%s%s:%s", hm.ModuleName, osh, hm.EventDescription)
+		} else {
+			// module hook
+			return fmt.Sprintf("%s:%s:%s", string(hm.BindingType), hm.HookName, hm.EventDescription)
 		}
-		return fmt.Sprintf("%s:%s%s", string(hm.BindingType), hm.HookName, osh)
 	}
 }


### PR DESCRIPTION
Now it is possible to tell why task was queued:

Restart of DiscoverModulesState on global values change by afterAll hooks:
```
GlobalHookRun:main:beforeAll:v1-hook-beforeall.sh:AfterAllHooksChangeGlobalValues
GlobalHookRun:main:beforeAll:v1-hook-kube.sh:AfterAllHooksChangeGlobalValues
DiscoverModulesState:main:::AfterAllHooksChangeGlobalValues
```

Module reload on values changes by afterHelm while processing DiscoverModulesState triggered by global values changes :open_mouth: :
```
ModuleRun:main::module-reload:GlobalValuesChanged.DiscoverModulesState.AfterHelmHooksChangeModuleValues
```

ModuleRun on absent resources detected:
```
ModuleRun:main::big-chart:DetectAbsentHelmResources
```

A batch of hooks with similar apiVersion and kind in kubernetes bindings:
```
GlobalHookRun:main:kubernetes:v1-hook-kube.sh:Kubernetes
ModuleHookRun:main:kubernetes:003-deploy-with-hooks/hooks/v1-hook-kube.sh:Kubernetes
ModuleHookRun:main:kubernetes:002-hooks-only/hooks/kube-hook.sh:Kubernetes
GlobalHookRun:main:kubernetes:v1-hook-kube.sh:Kubernetes
GlobalHookRun:main:kubernetes:v1-hook-kube.sh:Kubernetes
ModuleHookRun:main:kubernetes:002-hooks-only/hooks/kube-hook.sh:Kubernetes
ModuleHookRun:main:kubernetes:003-deploy-with-hooks/hooks/v1-hook-kube.sh:Kubernetes
ModuleHookRun:main:kubernetes:003-deploy-with-hooks/hooks/v1-hook-kube.sh:Kubernetes
GlobalHookRun:main:kubernetes:v1-hook-kube.sh:Kubernetes
ModuleHookRun:main:kubernetes:002-hooks-only/hooks/kube-hook.sh:Kubernetes
ModuleHookRun:main:kubernetes:003-deploy-with-hooks/hooks/v1-hook-kube.sh:Kubernetes
ModuleHookRun:main:kubernetes:002-hooks-only/hooks/kube-hook.sh:Kubernetes
GlobalHookRun:main:kubernetes:v1-hook-kube.sh:Kubernetes
```