### PR TITLE
feat: initial support for metrics from hooks

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -160,6 +160,7 @@ func (op *AddonOperator) InitModuleManager() error {
 	op.ModuleManager.WithKubeConfigManager(op.KubeConfigManager)
 	op.ModuleManager.WithScheduleManager(op.ScheduleManager)
 	op.ModuleManager.WithKubeEventManager(op.KubeEventsManager)
+	op.ModuleManager.WithMetricStorage(op.MetricStorage)
 	err = op.ModuleManager.Init()
 	if err != nil {
 		return fmt.Errorf("init module manager: %s", err)

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flant/addon-operator/pkg/helm_resources_manager"
 	"github.com/flant/shell-operator/pkg/hook/controller"
 	"github.com/flant/shell-operator/pkg/kube"
+	"github.com/flant/shell-operator/pkg/metrics_storage"
 	log "github.com/sirupsen/logrus"
 
 	// bindings constants and binding configs
@@ -41,6 +42,7 @@ type ModuleManager interface {
 	WithScheduleManager(schedule_manager.ScheduleManager)
 	WithKubeConfigManager(kubeConfigManager kube_config_manager.KubeConfigManager) ModuleManager
 	WithHelmResourcesManager(manager helm_resources_manager.HelmResourcesManager)
+	WithMetricStorage(storage *metrics_storage.MetricStorage)
 
 	GetModule(name string) *Module
 	GetModuleNamesInOrder() []string
@@ -102,6 +104,7 @@ type moduleManager struct {
 	kubeEventsManager    kube_events_manager.KubeEventsManager
 	scheduleManager      schedule_manager.ScheduleManager
 	HelmResourcesManager helm_resources_manager.HelmResourcesManager
+	metricStorage        *metrics_storage.MetricStorage
 
 	// Index of all modules in modules directory. Key is module name.
 	allModulesByName map[string]*Module
@@ -245,6 +248,10 @@ func (mm *moduleManager) WithScheduleManager(mgr schedule_manager.ScheduleManage
 
 func (mm *moduleManager) WithHelmResourcesManager(manager helm_resources_manager.HelmResourcesManager) {
 	mm.HelmResourcesManager = manager
+}
+
+func (mm *moduleManager) WithMetricStorage(storage *metrics_storage.MetricStorage) {
+	mm.metricStorage = storage
 }
 
 func (mm *moduleManager) WithContext(ctx context.Context) {

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+type MetricOperation struct {
+	Name   string            `json:"name"`
+	Add    *float64          `json:"add,omitempty"`
+	Set    *float64          `json:"set,omitempty"`
+	Labels map[string]string `json:"labels"`
+}
+
+func MetricOperationsFromReader(r io.Reader) ([]MetricOperation, error) {
+	var operations = make([]MetricOperation, 0)
+
+	dec := json.NewDecoder(r)
+	for {
+		var metricOperation MetricOperation
+		if err := dec.Decode(&metricOperation); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		operations = append(operations, metricOperation)
+	}
+
+	return operations, nil
+}
+
+func MetricOperationsFromBytes(data []byte) ([]MetricOperation, error) {
+	return MetricOperationsFromReader(bytes.NewReader(data))
+}
+
+func MetricOperationsFromFile(filePath string) ([]MetricOperation, error) {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %s", filePath, err)
+	}
+
+	if len(data) == 0 {
+		return nil, nil
+	}
+	return MetricOperationsFromBytes(data)
+}


### PR DESCRIPTION
New temporary file $METRIC_PATH can be filled with JSON objects that
desribe operations with prometheus metrics. The Addon-operator parses
this file and publish metrics via /metrics endpoint.

Example:

cat <<EOF >> $METRICS_PATH
  {"name":"metric_gauge", "set":34.12, "labels":{"label1":"val1", ... }}
  {"name":"metric_count", "add":1, "labels":{"label1":"val1", ... }}
EOF

These JSON objects become these metrics:

  metric_gauge{"hook":"hook.sh", "label1":"val1"} 34.12
  metric_count{"hook":"hook.sh", "label1":"val1"} 1

The Addon-operator adds labels to metrics: "hook" and "module" for
metrics from module hooks and "hook" for metrics from global hooks.

_This PR relates to issue in shell-operator_ https://github.com/flant/shell-operator/issues/130