### PR TITLE
fix: remove 'output' label for tiller subprocess logs

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -1070,7 +1070,6 @@ func (op *AddonOperator) TaskHandler(t sh_task.Task) queue.TaskResult {
 				op.MetricStorage.SendCounter("module_hook_allowed_errors", 1.0, map[string]string{"module": moduleLabel, "hook": hookLabel})
 				taskLogEntry.Infof("Module hook failed, but allowed to fail. Error: %v", err)
 				res.Status = "Success"
-				op.HelmResourcesManager.ResumeMonitor(hm.ModuleName)
 			} else {
 				op.MetricStorage.SendCounter("module_hook_errors", 1.0, map[string]string{"module": moduleLabel, "hook": hookLabel})
 				taskLogEntry.Errorf("Module hook failed, requeue task to retry after delay. Failed count is %d. Error: %s", t.GetFailureCount()+1, err)
@@ -1080,8 +1079,8 @@ func (op *AddonOperator) TaskHandler(t sh_task.Task) queue.TaskResult {
 		} else {
 			taskLogEntry.Infof("Module hook success")
 			res.Status = "Success"
-			op.HelmResourcesManager.ResumeMonitor(hm.ModuleName)
 		}
+		op.HelmResourcesManager.ResumeMonitor(hm.ModuleName)
 
 	case task.ModulePurge:
 		// Purge is for unknown modules, so error is just ignored.

--- a/pkg/helm/tiller.go
+++ b/pkg/helm/tiller.go
@@ -163,9 +163,6 @@ func TillerHealthHandler() func(writer http.ResponseWriter, request *http.Reques
 // StartAndLogLines is a non-blocking version of RunAndLogLines in shell-operator/pkg/executor.
 func StartAndLogLines(cmd *exec.Cmd, logLabels map[string]string) error {
 	logEntry := log.WithFields(utils.LabelsToLogFields(logLabels))
-	stdoutLogEntry := logEntry.WithField("output", "stdout")
-	stderrLogEntry := logEntry.WithField("output", "stderr")
-
 	logEntry.Debugf("Executing command '%s' in '%s' dir", strings.Join(cmd.Args, " "), cmd.Dir)
 
 	stdout, err := cmd.StdoutPipe()
@@ -187,14 +184,14 @@ func StartAndLogLines(cmd *exec.Cmd, logLabels map[string]string) error {
 	go func() {
 		scanner := bufio.NewScanner(stdout)
 		for scanner.Scan() {
-			stdoutLogEntry.Info(scanner.Text())
+			logEntry.Info(scanner.Text())
 		}
 	}()
 	// read and log stderr lines
 	go func() {
 		scanner := bufio.NewScanner(stderr)
 		for scanner.Scan() {
-			stderrLogEntry.Info(scanner.Text())
+			logEntry.Info(scanner.Text())
 		}
 	}()
 	return nil


### PR DESCRIPTION

_A continuation of #121_ 