### PR TITLE
Cumulative update: observability, metrics cleaner and fixes

### DIFF
--- a/cmd/addon-operator/main.go
+++ b/cmd/addon-operator/main.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"fmt"
-	"os"
-
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
+	"os"
 
 	sh_app "github.com/flant/shell-operator/pkg/app"
 	"github.com/flant/shell-operator/pkg/debug"
@@ -42,7 +41,8 @@ func main() {
 
 			// Block action by waiting signals from OS.
 			utils_signal.WaitForProcessInterruption(func() {
-				operator.Stop()
+				operator.Shutdown()
+				os.Exit(1)
 			})
 
 			return nil

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.5.0+incompatible
-	github.com/flant/shell-operator v1.0.0-beta.9.0.20200525114037-935a9c01a368 // branch: master
+	github.com/flant/shell-operator v1.0.0-beta.10.0.20200526112906-2d1bb9208462 // branch: feat_observability
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/spec v0.19.3
 	github.com/kennygrant/sanitize v1.2.4

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.5.0+incompatible
-	github.com/flant/shell-operator v1.0.0-beta.10.0.20200526112906-2d1bb9208462 // branch: feat_observability
+	github.com/flant/shell-operator v1.0.0-beta.10.0.20200529085426-c43a048da7ad // branch: feat_observability + fix_exit
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/spec v0.19.3
 	github.com/kennygrant/sanitize v1.2.4

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.5.0+incompatible
-	github.com/flant/shell-operator v1.0.0-beta.10.0.20200529085426-c43a048da7ad // branch: feat_observability + fix_exit
+	github.com/flant/shell-operator v1.0.0-beta.10.0.20200602130536-4ce071046165 // branch: feat_observability + fix_exit + feat_metric_cleaning
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/spec v0.19.3
 	github.com/kennygrant/sanitize v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,12 @@ github.com/flant/shell-operator v1.0.0-beta.10.0.20200526112906-2d1bb9208462 h1:
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200526112906-2d1bb9208462/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200529085426-c43a048da7ad h1:/ukFW8GMK0s5eFUE8Xe1KTEo8/CVNZ/uUmxGh+Tnex8=
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200529085426-c43a048da7ad/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200602110459-c3a33a1d8fb6 h1:4A0wBFM1Memc55pxYSeClO6BkT1+QC4kuNgdSTGhl64=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200602110459-c3a33a1d8fb6/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200602121156-2767ed85cd7d h1:n/+2G1KbrdTXrP8RWEm7e/xP354vOJsTBUQLlLqPZuo=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200602121156-2767ed85cd7d/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200602130536-4ce071046165 h1:0s4RSQ5ndONlPJgIySRda44X2OcwwGoN2AHDMnmiXOI=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200602130536-4ce071046165/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/flant/shell-operator v1.0.0-beta.9.0.20200525114037-935a9c01a368 h1:u
 github.com/flant/shell-operator v1.0.0-beta.9.0.20200525114037-935a9c01a368/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200526112906-2d1bb9208462 h1:0y4D3NZ6bFLiVYYflWCqnWF2iO67i7wkhO6FNNy/Mbw=
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200526112906-2d1bb9208462/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200529085426-c43a048da7ad h1:/ukFW8GMK0s5eFUE8Xe1KTEo8/CVNZ/uUmxGh+Tnex8=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200529085426-c43a048da7ad/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -87,7 +87,10 @@ github.com/flant/shell-operator v1.0.0-beta.9 h1:m6dMkgeTLYTVZ6D3Bw+Z/KY/1tfFJ9k
 github.com/flant/shell-operator v1.0.0-beta.9/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
 github.com/flant/shell-operator v1.0.0-beta.9.0.20200519120632-a644bd3f8ab3 h1:xPRNMtcT838WqG9nyeziG18ioS6PWxMbqZ7Pp+OkiWQ=
 github.com/flant/shell-operator v1.0.0-beta.9.0.20200519120632-a644bd3f8ab3/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
+github.com/flant/shell-operator v1.0.0-beta.9.0.20200525114037-935a9c01a368 h1:uefztkeUp92HVIQjulziJILhcDH5aTVCfkAJW4rdUTg=
 github.com/flant/shell-operator v1.0.0-beta.9.0.20200525114037-935a9c01a368/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200526112906-2d1bb9208462 h1:0y4D3NZ6bFLiVYYflWCqnWF2iO67i7wkhO6FNNy/Mbw=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200526112906-2d1bb9208462/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -1085,8 +1085,11 @@ func (op *AddonOperator) HandleModuleRun(t sh_task.Task, labels map[string]strin
 				logEntry.Errorf("Possible bug!!! Synchronization is needed, %d tasks should be waited before run beforeHelm, but module has state 'Synchronization is not queued'", len(waitSyncTasks))
 			}
 
-			// Enter wait loop if there are tasks that should be waited
-			if len(mainSyncTasks)+len(waitSyncTasks) > 0 {
+			// Enter wait loop if there are tasks that should be waited.
+			// Synchronization is there are no tasks to wait.
+			if len(mainSyncTasks)+len(waitSyncTasks) == 0 {
+				module.State.SynchronizationDone = true
+			} else {
 				module.State.ShouldWaitForSynchronization = true
 			}
 			// prevent task queueing on next ModuleRun

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -1412,10 +1412,11 @@ func (op *AddonOperator) HandleGlobalHookRun(t sh_task.Task, labels map[string]s
 					OnStartupHooks:   false,
 				})
 			res.TailTasks = []sh_task.Task{reloadAllModulesTask}
-		} else {
-			// pause-resume all monitors is not working with parallel hooks.
-			//op.HelmResourcesManager.ResumeMonitors()
 		}
+		// TODO rethink helm monitors pause-resume. It is not working well with parallel hooks without locks. But locks will destroy parallelization.
+		//else {
+		//	op.HelmResourcesManager.ResumeMonitors()
+		//}
 	}
 
 	if res.Status == "Success" {

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -1848,6 +1848,11 @@ func (op *AddonOperator) CheckConvergeStatus(t sh_task.Task) {
 	}
 }
 
+func (op *AddonOperator) Shutdown() {
+	op.KubeConfigManager.Stop()
+	op.ShellOperator.Shutdown()
+}
+
 func DefaultOperator() *AddonOperator {
 	operator := NewAddonOperator()
 	operator.WithContext(context.Background())

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -1115,7 +1115,7 @@ func (op *AddonOperator) HandleModuleRun(t sh_task.Task, labels map[string]strin
 			// remove temporary subqueue
 			op.TaskQueues.Remove(syncQueueName)
 		} else {
-			logEntry.Info("Module run repeat")
+			logEntry.Debugf("Module run repeat")
 			res.Status = "Repeat"
 			return
 		}

--- a/pkg/helm_resources_manager/helm_resources_manager.go
+++ b/pkg/helm_resources_manager/helm_resources_manager.go
@@ -17,6 +17,8 @@ type HelmResourcesManager interface {
 	WithDefaultNamespace(namespace string)
 	Stop()
 	StopMonitors()
+	PauseMonitors()
+	ResumeMonitors()
 	StartMonitor(moduleName string, manifests []manifest.Manifest, defaultNamespace string)
 	HasMonitor(moduleName string) bool
 	StopMonitor(moduleName string)
@@ -100,6 +102,18 @@ func (hm *helmResourcesManager) absentResourcesCallback(moduleName string, absen
 func (hm *helmResourcesManager) StopMonitors() {
 	for moduleName := range hm.monitors {
 		hm.StopMonitor(moduleName)
+	}
+}
+
+func (hm *helmResourcesManager) PauseMonitors() {
+	for _, monitor := range hm.monitors {
+		monitor.Pause()
+	}
+}
+
+func (hm *helmResourcesManager) ResumeMonitors() {
+	for _, monitor := range hm.monitors {
+		monitor.Resume()
 	}
 }
 

--- a/pkg/module_manager/hook_executor.go
+++ b/pkg/module_manager/hook_executor.go
@@ -10,7 +10,7 @@ import (
 	sh_app "github.com/flant/shell-operator/pkg/app"
 	"github.com/flant/shell-operator/pkg/executor"
 	. "github.com/flant/shell-operator/pkg/hook/binding_context"
-	"github.com/flant/shell-operator/pkg/metrics_storage"
+	metric_operation "github.com/flant/shell-operator/pkg/metrics_storage/operation"
 
 	"github.com/flant/addon-operator/pkg/helm"
 	"github.com/flant/addon-operator/pkg/utils"
@@ -40,7 +40,7 @@ func (e *HookExecutor) WithLogLabels(logLabels map[string]string) {
 	e.LogLabels = logLabels
 }
 
-func (e *HookExecutor) Run() (patches map[utils.ValuesPatchType]*utils.ValuesPatch, metrics []metrics_storage.MetricOperation, err error) {
+func (e *HookExecutor) Run() (patches map[utils.ValuesPatchType]*utils.ValuesPatch, metrics []metric_operation.MetricOperation, err error) {
 	patches = make(map[utils.ValuesPatchType]*utils.ValuesPatch)
 
 	bindingContextBytes, err := e.Context.Json()
@@ -93,7 +93,7 @@ func (e *HookExecutor) Run() (patches map[utils.ValuesPatchType]*utils.ValuesPat
 		return nil, nil, fmt.Errorf("got bad json patch for values: %s", err)
 	}
 
-	metrics, err = metrics_storage.MetricOperationsFromFile(e.MetricsPath)
+	metrics, err = metric_operation.MetricOperationsFromFile(e.MetricsPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("got bad metrics: %s", err)
 	}

--- a/pkg/module_manager/module.go
+++ b/pkg/module_manager/module.go
@@ -58,6 +58,9 @@ type ModuleState struct {
 
 	// become true if no synchronization task is needed or when queued synchronization tasks are finished
 	SynchronizationDone bool
+
+	// flag to prevent excess monitor starts
+	MonitorsStarted bool
 }
 
 func NewModule(name, path string) *Module {

--- a/pkg/module_manager/module.go
+++ b/pkg/module_manager/module.go
@@ -1,14 +1,15 @@
 package module_manager
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime/trace"
 	"strings"
 
-	"github.com/flant/shell-operator/pkg/utils/manifest"
 	"github.com/kennygrant/sanitize"
 	log "github.com/sirupsen/logrus"
 	uuid "gopkg.in/satori/go.uuid.v1"
@@ -16,10 +17,13 @@ import (
 	. "github.com/flant/addon-operator/pkg/hook/types"
 	. "github.com/flant/shell-operator/pkg/hook/binding_context"
 	. "github.com/flant/shell-operator/pkg/hook/types"
+	. "github.com/flant/shell-operator/pkg/utils/measure"
 
 	sh_app "github.com/flant/shell-operator/pkg/app"
 	"github.com/flant/shell-operator/pkg/executor"
+	"github.com/flant/shell-operator/pkg/metrics_storage"
 	utils_file "github.com/flant/shell-operator/pkg/utils/file"
+	"github.com/flant/shell-operator/pkg/utils/manifest"
 
 	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm"
@@ -42,6 +46,7 @@ type Module struct {
 	IsReady bool
 
 	moduleManager *moduleManager
+	metricStorage *metrics_storage.MetricStorage
 }
 
 type ModuleState struct {
@@ -65,6 +70,10 @@ func NewModule(name, path string) *Module {
 
 func (m *Module) WithModuleManager(moduleManager *moduleManager) {
 	m.moduleManager = moduleManager
+}
+
+func (m *Module) WithMetricStorage(mstor *metrics_storage.MetricStorage) {
+	m.metricStorage = mstor
 }
 
 func (m *Module) SafeName() string {
@@ -120,7 +129,7 @@ func (m *Module) RunOnStartup(logLabels map[string]string) error {
 	}
 
 	// Hooks can delete release resources, so stop resources monitor before run hooks.
-	m.moduleManager.HelmResourcesManager.StopMonitor(m.Name)
+	// m.moduleManager.HelmResourcesManager.PauseMonitor(m.Name)
 
 	if err := m.runHooksByBinding(OnStartup, logLabels); err != nil {
 		return err
@@ -132,6 +141,8 @@ func (m *Module) RunOnStartup(logLabels map[string]string) error {
 // Run is a phase of module lifecycle that runs onStartup and beforeHelm hooks, helm upgrade --install command and afterHelm hook.
 // It is a handler of task MODULE_RUN
 func (m *Module) Run(logLabels map[string]string) (bool, error) {
+	defer trace.StartRegion(context.Background(), "ModuleRun-HelmPhase")
+
 	logLabels = utils.MergeLabels(logLabels, map[string]string{
 		"module": m.Name,
 		"queue":  "main",
@@ -141,18 +152,29 @@ func (m *Module) Run(logLabels map[string]string) (bool, error) {
 		return false, err
 	}
 
-	// Hooks can delete release resources, so stop resources monitor before run hooks.
-	m.moduleManager.HelmResourcesManager.StopMonitor(m.Name)
+	// Hooks can delete release resources, so pause resources monitor before run hooks.
+	m.moduleManager.HelmResourcesManager.PauseMonitor(m.Name)
+	defer m.moduleManager.HelmResourcesManager.ResumeMonitor(m.Name)
 
-	if err := m.runHooksByBinding(BeforeHelm, logLabels); err != nil {
+	var err error
+
+	treg := trace.StartRegion(context.Background(), "ModuleRun-HelmPhase-beforeHelm")
+	err = m.runHooksByBinding(BeforeHelm, logLabels)
+	treg.End()
+	if err != nil {
 		return false, err
 	}
 
-	if err := m.runHelmInstall(logLabels); err != nil {
+	treg = trace.StartRegion(context.Background(), "ModuleRun-HelmPhase-helm")
+	err = m.runHelmInstall(logLabels)
+	treg.End()
+	if err != nil {
 		return false, err
 	}
 
+	treg = trace.StartRegion(context.Background(), "ModuleRun-HelmPhase-afterHelm")
 	valuesChanged, err := m.runHooksByBindingAndCheckValues(AfterHelm, logLabels)
+	treg.End()
 	if err != nil {
 		return false, err
 	}
@@ -222,6 +244,14 @@ func (m *Module) cleanup() error {
 }
 
 func (m *Module) runHelmInstall(logLabels map[string]string) error {
+	metricLabels := map[string]string{
+		"module":     m.Name,
+		"activation": logLabels["event.type"],
+	}
+	defer MeasureTime(func(nanos Nanos) {
+		m.metricStorage.ObserveHistogram("module_helm_hist", nanos.Ms(), metricLabels)
+	})()
+
 	logEntry := log.WithFields(utils.LabelsToLogFields(logLabels))
 
 	chartExists, err := m.checkHelmChart()
@@ -239,14 +269,29 @@ func (m *Module) runHelmInstall(logLabels map[string]string) error {
 		return err
 	}
 
-	// Render templates to prevent excess helm runs.
 	helmClient := helm.NewClient(logLabels)
-	renderedManifests, err := helmClient.Render(
-		helmReleaseName,
-		m.Path,
-		[]string{valuesPath},
-		[]string{},
-		app.Namespace)
+
+	// Render templates to prevent excess helm runs.
+	var renderedManifests string
+	func() {
+		defer trace.StartRegion(context.Background(), "ModuleRun-HelmPhase-helm-render").End()
+
+		metricLabels := map[string]string{
+			"module":     m.Name,
+			"activation": logLabels["event.type"],
+			"operation":  "template",
+		}
+		defer MeasureTime(func(nanos Nanos) {
+			m.metricStorage.ObserveHistogram("helm_operation_hist", nanos.Ms(), metricLabels)
+		})()
+
+		renderedManifests, err = helmClient.Render(
+			helmReleaseName,
+			m.Path,
+			[]string{valuesPath},
+			[]string{},
+			app.Namespace)
+	}()
 	if err != nil {
 		return err
 	}
@@ -259,7 +304,21 @@ func (m *Module) runHelmInstall(logLabels map[string]string) error {
 	m.LastReleaseManifests = manifests
 
 	// Skip upgrades if nothing is changes
-	runUpgradeRelease, err := m.ShouldRunHelmUpgrade(helmClient, helmReleaseName, checksum, manifests, logLabels)
+	var runUpgradeRelease bool
+	func() {
+		defer trace.StartRegion(context.Background(), "ModuleRun-HelmPhase-helm-check-upgrade").End()
+
+		metricLabels := map[string]string{
+			"module":     m.Name,
+			"activation": logLabels["event.type"],
+			"operation":  "check-upgrade",
+		}
+		defer MeasureTime(func(nanos Nanos) {
+			m.metricStorage.ObserveHistogram("helm_operation_hist", nanos.Ms(), metricLabels)
+		})()
+
+		runUpgradeRelease, err = m.ShouldRunHelmUpgrade(helmClient, helmReleaseName, checksum, manifests, logLabels)
+	}()
 	if err != nil {
 		return err
 	}
@@ -272,17 +331,33 @@ func (m *Module) runHelmInstall(logLabels map[string]string) error {
 		return nil
 	}
 
-	err = helmClient.UpgradeRelease(
-		helmReleaseName,
-		m.Path,
-		[]string{valuesPath},
-		[]string{fmt.Sprintf("_addonOperatorModuleChecksum=%s", checksum)},
-		//helm.Client.TillerNamespace(),
-		app.Namespace,
-	)
+	// Run helm upgrade. Trace and measure its time.
+	func() {
+		defer trace.StartRegion(context.Background(), "ModuleRun-HelmPhase-helm-upgrade").End()
+
+		metricLabels := map[string]string{
+			"module":     m.Name,
+			"activation": logLabels["event.type"],
+			"operation":  "upgrade",
+		}
+		defer MeasureTime(func(nanos Nanos) {
+			m.metricStorage.ObserveHistogram("helm_operation_hist", nanos.Ms(), metricLabels)
+		})()
+
+		err = helmClient.UpgradeRelease(
+			helmReleaseName,
+			m.Path,
+			[]string{valuesPath},
+			[]string{fmt.Sprintf("_addonOperatorModuleChecksum=%s", checksum)},
+			//helm.Client.TillerNamespace(),
+			app.Namespace,
+		)
+	}()
+
 	if err != nil {
 		return err
 	}
+
 	// Start monitor resources if release was successful
 	m.moduleManager.HelmResourcesManager.StartMonitor(m.Name, manifests, app.Namespace)
 
@@ -370,7 +445,20 @@ func (m *Module) runHooksByBinding(binding BindingType, logLabels map[string]str
 		}
 		bc.Metadata.BindingType = binding
 
-		err := moduleHook.Run(binding, []BindingContext{bc}, logLabels)
+		metricLabels := map[string]string{
+			"module":     m.Name,
+			"hook":       moduleHook.Name,
+			"binding":    string(binding),
+			"activation": logLabels["event.type"],
+		}
+
+		var err error
+		func() {
+			defer MeasureTime(func(nanos Nanos) {
+				m.metricStorage.ObserveHistogram("module_hook_run_hist", nanos.Ms(), metricLabels)
+			})()
+			err = moduleHook.Run(binding, []BindingContext{bc}, logLabels)
+		}()
 		if err != nil {
 			return err
 		}
@@ -406,7 +494,20 @@ func (m *Module) runHooksByBindingAndCheckValues(binding BindingType, logLabels 
 		}
 		bc.Metadata.BindingType = binding
 
-		err := moduleHook.Run(binding, []BindingContext{bc}, logLabels)
+		metricLabels := map[string]string{
+			"module":     m.Name,
+			"hook":       moduleHook.Name,
+			"binding":    string(binding),
+			"activation": logLabels["event.type"],
+		}
+
+		var err error
+		func() {
+			defer MeasureTime(func(nanos Nanos) {
+				m.metricStorage.ObserveHistogram("module_hook_run_hist", nanos.Ms(), metricLabels)
+			})()
+			err = moduleHook.Run(binding, []BindingContext{bc}, logLabels)
+		}()
 		if err != nil {
 			return false, err
 		}
@@ -783,6 +884,7 @@ func (mm *moduleManager) RegisterModules() error {
 		logEntry := log.WithField("module", module.Name)
 
 		module.WithModuleManager(mm)
+		module.WithMetricStorage(mm.metricStorage)
 
 		// load static config from values.yaml
 		err := module.loadStaticValues()


### PR DESCRIPTION
- feat: observability for hooks, queues, Kubernetes events handling
- feat: cleaner for metrics from hooks 
- fix: run helm upgrade even if no Synchronization tasks are queued
- fix: wait for queues on exit
- fix: informer go routines leakage on ReloadAllModules

See https://github.com/flant/shell-operator/pull/176


