### PR TITLE
feat: full object in snapshot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.5.0+incompatible
-	github.com/flant/shell-operator v1.0.0-beta.10.0.20200605114414-b093ff97d0d5 // branch: master
+	github.com/flant/shell-operator v1.0.0-beta.10.0.20200611102506-9a9f0ae49cd3 // branch: master
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/spec v0.19.3
 	github.com/kennygrant/sanitize v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/flant/libjq-go v1.0.1-0.20200205115921-27e93c18c17f h1:3tmztWJjf61sHf
 github.com/flant/libjq-go v1.0.1-0.20200205115921-27e93c18c17f/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/libjq-go v1.6.1-0.20200401092614-198670408da1 h1:pOPBJDB7PZz/SKa13mlR3bvkRJ0KWKRe6v+KZOObkKw=
 github.com/flant/libjq-go v1.6.1-0.20200401092614-198670408da1/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
+github.com/flant/libjq-go v1.6.1 h1:zEnucbRkoF3ytDWdK2GkS/iz6u7Hjd0LYPu/oEFaNJI=
 github.com/flant/libjq-go v1.6.1/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/shell-operator v1.0.0-beta.7.0.20200212144836-04e5d35edd9e h1:izyfBwGcWwz3tExPqvoaEQX9slaKNoapB0JnQvAtiAE=
 github.com/flant/shell-operator v1.0.0-beta.7.0.20200212144836-04e5d35edd9e/go.mod h1:2gRWBcUQHYT+OWaNvuUJ47m4zWyCi07ZqAj84OUgDzk=
@@ -102,6 +103,7 @@ github.com/flant/shell-operator v1.0.0-beta.10.0.20200602130536-4ce071046165 h1:
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200602130536-4ce071046165/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200602181144-b45a1c1db350 h1:AHhtsyYZwul/psnY5Nt0fifBb+HPo0FSLH+q+l55m8Q=
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200602181144-b45a1c1db350/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200605114414-b093ff97d0d5 h1:eJJ/SVmmrKIhmiQDFqAdoon6EPRc8GPib6bGwvM8Hjc=
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200605114414-b093ff97d0d5/go.mod h1:de2ktWYFz7RbmO+TkBqHTIUOCF8CAXYZKCHqCx0luCE=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/flant/shell-operator v1.0.0-beta.10.0.20200602181144-b45a1c1db350 h1:
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200602181144-b45a1c1db350/go.mod h1:Cf7KVE1Qy60dtA112nuOBo33Ef0xeoB2vil7iJULnEM=
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200605114414-b093ff97d0d5 h1:eJJ/SVmmrKIhmiQDFqAdoon6EPRc8GPib6bGwvM8Hjc=
 github.com/flant/shell-operator v1.0.0-beta.10.0.20200605114414-b093ff97d0d5/go.mod h1:de2ktWYFz7RbmO+TkBqHTIUOCF8CAXYZKCHqCx0luCE=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200611102506-9a9f0ae49cd3 h1:nsZLq5IfPQk6cZY1KpoEKjfrmC1ApunMkik2YOH3fkA=
+github.com/flant/shell-operator v1.0.0-beta.10.0.20200611102506-9a9f0ae49cd3/go.mod h1:de2ktWYFz7RbmO+TkBqHTIUOCF8CAXYZKCHqCx0luCE=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/kube_config_manager/kube_config_manager.go
+++ b/pkg/kube_config_manager/kube_config_manager.go
@@ -45,9 +45,8 @@ type kubeConfigManager struct {
 	ConfigMapName             string
 	ValuesChecksumsAnnotation string
 
-	initialConfig       *Config
-	currentConfig       *Config
-	currentModuleConfig ModuleConfigs
+	initialConfig *Config
+	currentConfig *Config
 
 	GlobalValuesChecksum  string
 	ModulesValuesChecksum map[string]string

--- a/pkg/module_manager/hook.go
+++ b/pkg/module_manager/hook.go
@@ -186,6 +186,11 @@ func (mm *moduleManager) RegisterGlobalHooks() error {
 		for _, kubeCfg := range globalHook.Config.OnKubernetesEvents {
 			kubeCfg.Monitor.Metadata.LogLabels["hook"] = globalHook.Name
 			kubeCfg.Monitor.Metadata.LogLabels["hook.type"] = "global"
+			kubeCfg.Monitor.Metadata.MetricLabels = map[string]string{
+				"hook":    globalHook.Name,
+				"binding": kubeCfg.BindingName,
+				"module":  "", // empty "module" label for label set consistency with module hooks
+			}
 		}
 
 		hookCtrl := controller.NewHookController()
@@ -248,6 +253,11 @@ func (mm *moduleManager) RegisterModuleHooks(module *Module, logLabels map[strin
 			kubeCfg.Monitor.Metadata.LogLabels["module"] = module.Name
 			kubeCfg.Monitor.Metadata.LogLabels["hook"] = moduleHook.Name
 			kubeCfg.Monitor.Metadata.LogLabels["hook.type"] = "module"
+			kubeCfg.Monitor.Metadata.MetricLabels = map[string]string{
+				"hook":    moduleHook.Name,
+				"binding": kubeCfg.BindingName,
+				"module":  module.Name,
+			}
 		}
 
 		hookCtrl := controller.NewHookController()

--- a/pkg/module_manager/module.go
+++ b/pkg/module_manager/module.go
@@ -144,7 +144,7 @@ func (m *Module) RunOnStartup(logLabels map[string]string) error {
 // Run is a phase of module lifecycle that runs onStartup and beforeHelm hooks, helm upgrade --install command and afterHelm hook.
 // It is a handler of task MODULE_RUN
 func (m *Module) Run(logLabels map[string]string) (bool, error) {
-	defer trace.StartRegion(context.Background(), "ModuleRun-HelmPhase")
+	defer trace.StartRegion(context.Background(), "ModuleRun-HelmPhase").End()
 
 	logLabels = utils.MergeLabels(logLabels, map[string]string{
 		"module": m.Name,
@@ -188,6 +188,8 @@ func (m *Module) Run(logLabels map[string]string) (bool, error) {
 // Delete removes helm release if it exists and runs afterDeleteHelm hooks.
 // It is a handler for MODULE_DELETE task.
 func (m *Module) Delete(logLabels map[string]string) error {
+	defer trace.StartRegion(context.Background(), "ModuleDelete-HelmPhase").End()
+
 	deleteLogLabels := utils.MergeLabels(logLabels,
 		map[string]string{
 			"module": m.Name,

--- a/pkg/module_manager/module.go
+++ b/pkg/module_manager/module.go
@@ -832,7 +832,7 @@ func (m *Module) checkIsEnabledByScript(precedingEnabledModules []string, logLab
 	if moduleEnabled {
 		result = "Enabled"
 	}
-	logEntry.Infof("Enabled script run successful, result: module %q", result)
+	logEntry.Infof("Enabled script run successful, result '%v', module '%s'", moduleEnabled, result)
 	return moduleEnabled, nil
 }
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -622,7 +622,7 @@ func (mm *moduleManager) Ch() chan Event {
 // DiscoverModulesState handles DiscoverModulesState event: it calculates new arrays of enabled modules,
 // modules that should be disabled and modules that should be purged.
 //
-// This method updates module state indicies and values
+// This method updates module state indices and values
 // - mm.enabledModulesByConfig
 // - mm.enabledModulesInOrder
 // - mm.kubeModulesConfigValues are updated.

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -698,12 +698,11 @@ func (mm *moduleManager) DiscoverModulesState(logLabels map[string]string) (stat
 	// save enabled modules for future usages
 	mm.enabledModulesInOrder = enabledModules
 
-	// Calculate modules that has helm release and are disabled for now.
+	// Calculate disabled known modules that has helm release and/or was enabled.
 	// Sort them in reverse order for proper deletion.
-	// FIXME releasedModules do not contain enabled modules without helm chart.
 	state.ModulesToDisable = utils.ListSubtract(mm.allModulesNamesInOrder, enabledModules)
-	//state.ModulesToDisable = utils.ListIntersection(state.ModulesToDisable, releasedModules)
-	state.ModulesToDisable = utils.ListIntersection(state.ModulesToDisable, currentEnabledModules)
+	enabledAndReleased := utils.ListUnion(currentEnabledModules, releasedModules)
+	state.ModulesToDisable = utils.ListIntersection(state.ModulesToDisable, enabledAndReleased)
 	// disable modules in reverse order
 	state.ModulesToDisable = utils.SortReverseByReference(state.ModulesToDisable, mm.allModulesNamesInOrder)
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -2,7 +2,9 @@ package module_manager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	utils_checksum "github.com/flant/shell-operator/pkg/utils/checksum"
 	"reflect"
 	"sort"
 	"strings"
@@ -76,6 +78,9 @@ type ModuleManager interface {
 	DisableModuleHooks(moduleName string)
 	HandleScheduleEvent(crontab string, createGlobalTaskFn func(*GlobalHook, controller.BindingExecutionInfo), createModuleTaskFn func(*Module, *ModuleHook, controller.BindingExecutionInfo)) error
 
+	DynamicEnabledChecksum() string
+	ApplyEnabledPatch(enabledPatch utils.ValuesPatch) error
+
 	GlobalSynchronizationNeeded() bool
 	GlobalSynchronizationDone() bool
 	SynchronizationQueued(id string)
@@ -128,11 +133,9 @@ type moduleManager struct {
 	// dynamicEnabledValues utils.Values // patches from global hooks
 	// scriptEnabledValues utils.Values // enabled script results
 
-	// onStartup+beforeAll
-	// dynamicEnabledValues utils.Values // patches from global hooks
-
 	// values::set "moduleNameEnabled" "\"true\""
-	// module::enable "module_kebab" "true"
+	// module enable values from global hooks
+	dynamicEnabled map[string]*bool
 
 	// List of modules enabled by values.yaml or by kube config.
 	// This list is changed on ConfigMap updates.
@@ -233,6 +236,7 @@ func NewMainModuleManager() *moduleManager {
 		allModulesNamesInOrder:      make([]string, 0),
 		enabledModulesByConfig:      make([]string, 0),
 		enabledModulesInOrder:       make([]string, 0),
+		dynamicEnabled:              make(map[string]*bool),
 		globalHooksByName:           make(map[string]*GlobalHook),
 		globalHooksOrder:            make(map[BindingType][]*GlobalHook),
 		modulesHooksOrderByName:     make(map[string]map[BindingType][]*ModuleHook),
@@ -349,7 +353,8 @@ func (mm *moduleManager) handleNewKubeConfig(newConfig kube_config_manager.Confi
 	res.EnabledModulesByConfig, res.KubeModulesConfigValues, unknown = mm.calculateEnabledModulesByConfig(newConfig.ModuleConfigs)
 
 	for _, moduleConfig := range unknown {
-		logEntry.Warnf("Ignore kube config for absent module : \n%s",
+		logEntry.Warnf("Ignore ConfigMap section '%s' for absent module : \n%s",
+			moduleConfig.ModuleName,
 			moduleConfig.String(),
 		)
 	}
@@ -383,12 +388,17 @@ func (mm *moduleManager) handleNewKubeModuleConfigs(moduleConfigs kube_config_ma
 
 	// Detect removed module sections for statically enabled modules.
 	// This removal should be handled like kube config update.
-	updateAfterRemoval := make(map[string]bool)
+	updateOnSectionRemove := make(map[string]bool)
 	for moduleName, module := range mm.allModulesByName {
 		_, hasKubeConfig := moduleConfigs[moduleName]
-		if !hasKubeConfig && mergeEnabled(module.CommonStaticConfig.IsEnabled, module.StaticConfig.IsEnabled) {
-			if _, hasValues := mm.kubeModulesConfigValues[moduleName]; hasValues {
-				updateAfterRemoval[moduleName] = true
+		if !hasKubeConfig {
+			isEnabled := mergeEnabled(
+				module.CommonStaticConfig.IsEnabled,
+				module.StaticConfig.IsEnabled,
+				mm.dynamicEnabled[moduleName])
+			_, hasValues := mm.kubeModulesConfigValues[moduleName]
+			if isEnabled && hasValues {
+				updateOnSectionRemove[moduleName] = true
 			}
 		}
 	}
@@ -409,7 +419,7 @@ func (mm *moduleManager) handleNewKubeModuleConfigs(moduleConfigs kube_config_ma
 		// Enabled modules set is changed — return GlobalChanged event, that will
 		// create a Discover task, run enabled scripts again, init new module hooks,
 		// update mm.enabledModulesInOrder
-		logEntry.Debugf("enabledByConfig changed from %v to %v: generate GlobalChanged event", mm.enabledModulesByConfig, res.EnabledModulesByConfig)
+		logEntry.Debugf("enabled modules set changed from %v to %v: generate GlobalChanged event", mm.enabledModulesInOrder, res.EnabledModulesByConfig)
 		res.Events = append(res.Events, Event{Type: GlobalChanged})
 	} else {
 		// Enabled modules set is not changed, only values in configmap are changed.
@@ -433,7 +443,7 @@ func (mm *moduleManager) handleNewKubeModuleConfigs(moduleConfigs kube_config_ma
 			}
 
 			// Update module if kube config is removed
-			_, shouldUpdateAfterRemoval := updateAfterRemoval[name]
+			_, shouldUpdateAfterRemoval := updateOnSectionRemove[name]
 
 			if (hasKubeConfig && isUpdated) || shouldUpdateAfterRemoval {
 				moduleChanges = append(moduleChanges, ModuleChange{Name: name, ChangeType: Changed})
@@ -450,7 +460,8 @@ func (mm *moduleManager) handleNewKubeModuleConfigs(moduleConfigs kube_config_ma
 	return res, nil
 }
 
-// calculateEnabledModulesByConfig determine enable state for all modules by values.yaml and ConfigMap configuration.
+// calculateEnabledModulesByConfig determine enable state for all modules
+// by values.yaml, ConfigMap and dynamicEnable map.
 // Method returns list of enabled modules and their values. Also the map of disabled modules and a list of unknown
 // keys in a ConfigMap.
 //
@@ -459,29 +470,40 @@ func (mm *moduleManager) handleNewKubeModuleConfigs(moduleConfigs kube_config_ma
 func (mm *moduleManager) calculateEnabledModulesByConfig(moduleConfigs kube_config_manager.ModuleConfigs) (enabled []string, values map[string]utils.Values, unknown []utils.ModuleConfig) {
 	values = make(map[string]utils.Values)
 
+	log.Debugf("calculateEnabled: dynamicEnabled is %s", mm.DumpDynamicEnabled())
+
 	for moduleName, module := range mm.allModulesByName {
 		kubeConfig, hasKubeConfig := moduleConfigs[moduleName]
 		if hasKubeConfig {
-			isEnabled := mergeEnabled(module.CommonStaticConfig.IsEnabled,
+			isEnabled := mergeEnabled(
+				module.CommonStaticConfig.IsEnabled,
 				module.StaticConfig.IsEnabled,
-				kubeConfig.IsEnabled)
-			// , mm.dynamicEnabled[moduleName])
+				kubeConfig.IsEnabled,
+				mm.dynamicEnabled[moduleName])
 
 			if isEnabled {
 				enabled = append(enabled, moduleName)
 				values[moduleName] = kubeConfig.Values
 			}
-			log.Debugf("Module %s: static enabled %v, kubeConfig: enabled %v, updated %v",
+			log.Debugf("calculateEnabled: module '%s': static enabled %v, kubeConfig: enabled %v, updated %v, dynamic enabled: %v",
 				module.Name,
 				module.StaticConfig.GetEnabled(),
 				kubeConfig.IsEnabled,
-				kubeConfig.IsUpdated)
+				kubeConfig.IsUpdated,
+				mm.dynamicEnabled[moduleName])
 		} else {
-			isEnabled := mergeEnabled(module.CommonStaticConfig.IsEnabled, module.StaticConfig.IsEnabled)
+			isEnabled := mergeEnabled(
+				module.CommonStaticConfig.IsEnabled,
+				module.StaticConfig.IsEnabled,
+				mm.dynamicEnabled[moduleName])
+
 			if isEnabled {
 				enabled = append(enabled, moduleName)
 			}
-			log.Debugf("Module %s: static enabled %v, no kubeConfig", module.Name, module.StaticConfig.GetEnabled())
+			log.Debugf("calculateEnabled: module '%s': static enabled %v, no kubeConfig, dynamic enabled: %v",
+				module.Name,
+				module.StaticConfig.GetEnabled(),
+				mm.dynamicEnabled[moduleName])
 		}
 	}
 
@@ -565,23 +587,15 @@ func (mm *moduleManager) Start() {
 				// Сбросить запомненные перед ошибкой конфиги
 				mm.moduleConfigsUpdateBeforeAmbiguos = kube_config_manager.ModuleConfigs{}
 
-				handleRes, err := mm.handleNewKubeModuleConfigs(newModuleConfigs)
+				moduleUpdates, err := mm.handleNewKubeModuleConfigs(newModuleConfigs)
 				if err != nil {
 					mm.moduleConfigsUpdateBeforeAmbiguos = newModuleConfigs
-					modulesNames := make([]string, 0)
-					for _, newModuleConfig := range newModuleConfigs {
-						modulesNames = append(modulesNames, fmt.Sprintf("'%s'", newModuleConfig.ModuleName))
-					}
-					log.Errorf("Unable to handle update of ConfigMap for modules [%s]: %s", strings.Join(modulesNames, ", "), err)
+					log.Errorf("Unable to handle update of ConfigMap for modules [%s]: %s", strings.Join(newModuleConfigs.Names(), ", "), err)
 				}
-				if handleRes != nil {
-					err = mm.applyKubeUpdate(handleRes)
+				if moduleUpdates != nil {
+					err = mm.applyKubeUpdate(moduleUpdates)
 					if err != nil {
-						modulesNames := make([]string, 0)
-						for _, newModuleConfig := range newModuleConfigs {
-							modulesNames = append(modulesNames, fmt.Sprintf("'%s'", newModuleConfig.ModuleName))
-						}
-						log.Errorf("ConfigMap update cannot be applied to values for modules %s: %s", strings.Join(modulesNames, ", "), err)
+						log.Errorf("ConfigMap update cannot be applied to values for modules %s: %s", strings.Join(newModuleConfigs.Names(), ", "), err)
 					}
 				}
 
@@ -608,14 +622,31 @@ func (mm *moduleManager) Ch() chan Event {
 // DiscoverModulesState handles DiscoverModulesState event: it calculates new arrays of enabled modules,
 // modules that should be disabled and modules that should be purged.
 //
-// This method requires that mm.enabledModulesByConfig and mm.kubeModulesConfigValues are updated.
+// This method updates module state indicies and values
+// - mm.enabledModulesByConfig
+// - mm.enabledModulesInOrder
+// - mm.kubeModulesConfigValues are updated.
 func (mm *moduleManager) DiscoverModulesState(logLabels map[string]string) (state *ModulesState, err error) {
 	discoverLogLabels := utils.MergeLabels(logLabels, map[string]string{
 		"operator.component": "moduleManager.discoverModulesState",
 	})
 	logEntry := log.WithFields(utils.LabelsToLogFields(discoverLogLabels))
 
-	logEntry.Debugf("DISCOVER state:\n"+
+	logEntry.Debugf("DISCOVER state current:\n"+
+		"    mm.enabledModulesByConfig: %v\n"+
+		"    mm.enabledModulesInOrder:  %v\n",
+		mm.enabledModulesByConfig,
+		mm.enabledModulesInOrder)
+
+	currentEnabledModules := mm.enabledModulesInOrder
+
+	updateEnabledModules, updateModuleValues, _ := mm.calculateEnabledModulesByConfig(mm.kubeConfigManager.CurrentConfig().ModuleConfigs)
+	updateEnabledModules = utils.SortByReference(updateEnabledModules, mm.allModulesNamesInOrder)
+
+	mm.enabledModulesByConfig = updateEnabledModules
+	mm.kubeModulesConfigValues = updateModuleValues
+
+	logEntry.Debugf("DISCOVER state updated:\n"+
 		"    mm.enabledModulesByConfig: %v\n"+
 		"    mm.enabledModulesInOrder:  %v\n",
 		mm.enabledModulesByConfig,
@@ -635,6 +666,7 @@ func (mm *moduleManager) DiscoverModulesState(logLabels map[string]string) (stat
 
 	// calculate unknown released modules to purge them in reverse order
 	state.ReleasedUnknownModules = utils.ListSubtract(releasedModules, mm.allModulesNamesInOrder)
+	// purge unknown modules in reverse order
 	state.ReleasedUnknownModules = utils.SortReverse(state.ReleasedUnknownModules)
 	if len(state.ReleasedUnknownModules) > 0 {
 		logEntry.Infof("found modules with releases: %s", state.ReleasedUnknownModules)
@@ -668,18 +700,23 @@ func (mm *moduleManager) DiscoverModulesState(logLabels map[string]string) (stat
 
 	// Calculate modules that has helm release and are disabled for now.
 	// Sort them in reverse order for proper deletion.
+	// FIXME releasedModules do not contain enabled modules without helm chart.
 	state.ModulesToDisable = utils.ListSubtract(mm.allModulesNamesInOrder, enabledModules)
-	state.ModulesToDisable = utils.ListIntersection(state.ModulesToDisable, releasedModules)
+	//state.ModulesToDisable = utils.ListIntersection(state.ModulesToDisable, releasedModules)
+	state.ModulesToDisable = utils.ListIntersection(state.ModulesToDisable, currentEnabledModules)
+	// disable modules in reverse order
 	state.ModulesToDisable = utils.SortReverseByReference(state.ModulesToDisable, mm.allModulesNamesInOrder)
 
 	logEntry.Debugf("DISCOVER state results:\n"+
 		"    mm.enabledModulesByConfig: %v\n"+
-		"    EnabledModules: %v\n"+
+		"    mm.enabledModulesInOrder: %v\n"+
+		"    releasedModules: %v\n"+
 		"    ReleasedUnknownModules: %v\n"+
 		"    ModulesToDisable: %v\n"+
 		"    NewlyEnabled: %v\n",
 		mm.enabledModulesByConfig,
 		mm.enabledModulesInOrder,
+		releasedModules,
 		state.ReleasedUnknownModules,
 		state.ModulesToDisable,
 		state.NewlyEnabledModules)
@@ -1081,6 +1118,64 @@ func (mm *moduleManager) LoopByBinding(binding BindingType, fn func(gh *GlobalHo
 		}
 
 	}
+}
+
+func (mm *moduleManager) ApplyEnabledPatch(enabledPatch utils.ValuesPatch) error {
+	newDynamicEnabled := map[string]*bool{}
+	for k, v := range mm.dynamicEnabled {
+		newDynamicEnabled[k] = v
+	}
+
+	for _, op := range enabledPatch.Operations {
+		// Extract module name from json patch: '"path": "/moduleNameEnabled"'
+		modName := strings.TrimSuffix(op.Path, "Enabled")
+		modName = strings.TrimPrefix(modName, "/")
+		modName = utils.ModuleNameFromValuesKey(modName)
+
+		switch op.Op {
+		case "add":
+			v, err := utils.ModuleEnabledValue(op.Value)
+			if err != nil {
+				return fmt.Errorf("apply enabled patch operation '%s' for %s: ", op.Op, op.Path)
+			}
+			log.Debugf("apply dynamic enable: module %s set to '%v'", modName, *v)
+			newDynamicEnabled[modName] = v
+		case "remove":
+			log.Debugf("apply dynamic enable: module %s removed from dynamic enable", modName)
+			delete(newDynamicEnabled, modName)
+		}
+	}
+
+	mm.dynamicEnabled = newDynamicEnabled
+
+	log.Infof("dynamic enabled after patch: %s", mm.DumpDynamicEnabled())
+
+	return nil
+}
+
+// DynamicEnabledChecksum returns checksum for dynamicEnabled map
+func (mm *moduleManager) DynamicEnabledChecksum() string {
+	jsonBytes, err := json.Marshal(mm.dynamicEnabled)
+	if err != nil {
+		log.Errorf("dynamicEnabled checksum calculate from '%s': %v", mm.DumpDynamicEnabled(), err)
+	}
+	return utils_checksum.CalculateChecksum(string(jsonBytes))
+}
+
+func (mm *moduleManager) DumpDynamicEnabled() string {
+	dump := "["
+	for k, v := range mm.dynamicEnabled {
+		enabled := "nil"
+		if v != nil {
+			if *v {
+				enabled = "true"
+			} else {
+				enabled = "false"
+			}
+		}
+		dump += fmt.Sprintf("%s(%s), ", k, enabled)
+	}
+	return dump + "]"
 }
 
 // GlobalSynchronizationNeeded is true if there is at least one global

--- a/pkg/module_manager/module_manager_test.go
+++ b/pkg/module_manager/module_manager_test.go
@@ -1142,12 +1142,12 @@ func Test_MainModuleManager_DiscoverModulesState(t *testing.T) {
 			"discover_modules_state__with_enabled_scripts",
 			[]string{},
 			func() {
-				// if all modules are enabled by default, then beta should be disabled by script
+				// If all modules are enabled by default, then beta should be disabled by script.
 				assert.Equal(t, []string{"alpha", "gamma", "delta", "epsilon", "zeta", "eta"}, modulesState.EnabledModules)
 
-				// turn off alpha so gamma, delta and zeta should be disabled
-				// with the next call of DiscoverModulesState
-				mm.enabledModulesByConfig = []string{"beta", "gamma", "delta", "epsilon", "zeta", "eta"}
+				// Turn off alpha so gamma, delta and zeta should become disabled
+				// with the next call to DiscoverModulesState.
+				mm.dynamicEnabled["alpha"] = &utils.ModuleDisabled
 				modulesState, err = mm.DiscoverModulesState(map[string]string{})
 				assert.Equal(t, []string{"epsilon", "eta"}, modulesState.EnabledModules)
 			},

--- a/pkg/module_manager/testdata/discover_modules_state__module_names_order/config_map.yaml
+++ b/pkg/module_manager/testdata/discover_modules_state__module_names_order/config_map.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: addon-operator
+data:
+  global: {}

--- a/pkg/module_manager/testdata/discover_modules_state__simple/config_map.yaml
+++ b/pkg/module_manager/testdata/discover_modules_state__simple/config_map.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: addon-operator
+data:
+  global: {}

--- a/pkg/module_manager/testdata/discover_modules_state__with_enabled_scripts/config_map.yaml
+++ b/pkg/module_manager/testdata/discover_modules_state__with_enabled_scripts/config_map.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: addon-operator
+data:
+  global: {}

--- a/pkg/module_manager/testdata/discover_modules_state__with_enabled_scripts/modules/003-gamma/enabled
+++ b/pkg/module_manager/testdata/discover_modules_state__with_enabled_scripts/modules/003-gamma/enabled
@@ -2,10 +2,6 @@
 
 # dependency: alpha
 
-c=$(cat ${VALUES_PATH:-/dev/null} | jq .global.enabledModules[] | grep '"alpha"' | wc -l)
-if [ "$c" == "1" ] ; then
-  echo true > $MODULE_ENABLED_RESULT
-  exit 0
-fi
+# enabled if alpha is enabled
 
-echo false > $MODULE_ENABLED_RESULT
+cat ${VALUES_PATH:-/dev/null} | jq '.global.enabledModules | any(in({"alpha":1}))' > $MODULE_ENABLED_RESULT

--- a/pkg/module_manager/testdata/discover_modules_state__with_enabled_scripts/modules/004-delta/enabled
+++ b/pkg/module_manager/testdata/discover_modules_state__with_enabled_scripts/modules/004-delta/enabled
@@ -1,11 +1,6 @@
 #!/bin/bash
 
 # dependency: alpha
+# enabled if alpha is enabled
 
-c=$(cat ${VALUES_PATH:-/dev/null} | jq .global.enabledModules[]  | grep '"alpha"' | wc -l)
-if [ "$c" == "1" ] ; then
-  echo true > $MODULE_ENABLED_RESULT
-  exit 0
-fi
-
-echo false > $MODULE_ENABLED_RESULT
+cat ${VALUES_PATH:-/dev/null} | jq '.global.enabledModules | any(in({"alpha":1}))' > $MODULE_ENABLED_RESULT

--- a/pkg/module_manager/testdata/discover_modules_state__with_enabled_scripts/modules/006-zeta/enabled
+++ b/pkg/module_manager/testdata/discover_modules_state__with_enabled_scripts/modules/006-zeta/enabled
@@ -1,12 +1,8 @@
 #!/bin/bash
 
 # dependency: gamma
-# dependency: epsilon
+# dependency: delta
 
-c=$(cat ${VALUES_PATH:-/dev/null} | jq .global.enabledModules[]  | grep -P '"gamma"|"epsilon"' | wc -l)
-if [ "$c" == "2" ] ; then
-  echo true > $MODULE_ENABLED_RESULT
-  exit 0
-fi
+# enabled if gamma and delta are enabled
 
-echo false > $MODULE_ENABLED_RESULT
+cat ${VALUES_PATH:-/dev/null} | jq '.global.enabledModules | any(in({"gamma":1,"delta":1}))' > $MODULE_ENABLED_RESULT

--- a/pkg/module_manager/testdata/get__module_hooks_in_order/config_map.yaml
+++ b/pkg/module_manager/testdata/get__module_hooks_in_order/config_map.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: addon-operator
+data:
+  global: {}

--- a/pkg/task/hook_metadata.go
+++ b/pkg/task/hook_metadata.go
@@ -22,8 +22,9 @@ type HookMetadata struct {
 
 	OnStartupHooks bool // Execute onStartup and kubernetes@Synchronization hooks for module
 
-	LastAfterAllHook         bool   // True if task is a last hook in afterAll sequence
-	ValuesChecksum           string // checksum of global values between first afterAll hook execution
+	ValuesChecksum           string // checksum of global values before first afterAll hook execution
+	DynamicEnabledChecksum   string // checksum of dynamicEnabled before firts afterAll hook execution
+	LastAfterAllHook         bool   // true if task is a last afterAll hook in sequence
 	ReloadAllOnValuesChanges bool   // whether or not run DiscoverModules process if hook change global values
 
 	KubernetesBindingId    string // Unique id for kubernetes bindings

--- a/pkg/task/hook_metadata.go
+++ b/pkg/task/hook_metadata.go
@@ -23,7 +23,7 @@ type HookMetadata struct {
 	OnStartupHooks bool // Execute onStartup and kubernetes@Synchronization hooks for module
 
 	ValuesChecksum           string // checksum of global values before first afterAll hook execution
-	DynamicEnabledChecksum   string // checksum of dynamicEnabled before firts afterAll hook execution
+	DynamicEnabledChecksum   string // checksum of dynamicEnabled before first afterAll hook execution
 	LastAfterAllHook         bool   // true if task is a last afterAll hook in sequence
 	ReloadAllOnValuesChanges bool   // whether or not run DiscoverModules process if hook change global values
 

--- a/pkg/utils/module_config.go
+++ b/pkg/utils/module_config.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/davecgh/go-spew/spew"
 	"sigs.k8s.io/yaml"
@@ -183,4 +184,23 @@ func (mc *ModuleConfig) FromConfigMapData(configData map[string]string) (*Module
 
 func (mc *ModuleConfig) Checksum() string {
 	return utils_checksum.CalculateChecksum(mc.RawConfig...)
+}
+
+func ModuleEnabledValue(i interface{}) (*bool, error) {
+	switch v := i.(type) {
+	case string:
+		switch strings.ToLower(v) {
+		case "true":
+			return &ModuleEnabled, nil
+		case "false":
+			return &ModuleDisabled, nil
+		}
+	case bool:
+		if v {
+			return &ModuleEnabled, nil
+		} else {
+			return &ModuleDisabled, nil
+		}
+	}
+	return nil, fmt.Errorf("unsupported module enabled value: %v", i)
 }

--- a/pkg/utils/module_list.go
+++ b/pkg/utils/module_list.go
@@ -94,6 +94,28 @@ func ListIntersection(arrs ...[]string) (result []string) {
 	return
 }
 
+// ListUnion creates a new array with unique items from all src arrays.
+func ListUnion(src []string, more ...[]string) []string {
+	m := make(map[string]struct{})
+	for _, v := range src {
+		m[v] = struct{}{}
+	}
+
+	for _, arr := range more {
+		for _, v := range arr {
+			m[v] = struct{}{}
+		}
+	}
+
+	res := make([]string, 0, len(m))
+
+	for k := range m {
+		res = append(res, k)
+	}
+
+	return res
+}
+
 // ListFullyIn returns whether all 'arr' items contains in `ref` array.
 func ListFullyIn(arr []string, ref []string) bool {
 	res := true


### PR DESCRIPTION
feat: keepFullObjectsInMemory for kubernetes binding contexts
- add hook, binding and module labels for _kube_jq_hist metric

feat: enable modules from global hooks
- recognize *Enabled paths in patches from global hooks
- queue ReloadAll task if enabled modules set is changed
- properly disable modules without the Helm release
*See #130*