### PR TITLE
feat: helm3 compatibility

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"strconv"
+	"time"
 
 	sh_app "github.com/flant/shell-operator/pkg/app"
 
@@ -21,6 +22,9 @@ var TillerListenPort int32 = 44434
 var TillerProbeListenAddress = "127.0.0.1"
 var TillerProbeListenPort int32 = 44435
 var TillerMaxHistory int32 = 0
+
+var Helm3HistoryMax int32 = 10
+var Helm3Timeout time.Duration = 5 * time.Minute
 
 var Namespace = ""
 var ConfigMapName = "addon-operator"
@@ -70,6 +74,16 @@ func DefineStartCommandFlags(kpApp *kingpin.Application, cmd *kingpin.CmdClause)
 		Envar("TILLER_MAX_HISTORY").
 		Default(strconv.Itoa(int(TillerMaxHistory))).
 		Int32Var(&TillerMaxHistory)
+
+	cmd.Flag("helm-history-max", "Helm: limit the maximum number of revisions saved per release. Use 0 for no limit.").
+		Envar("HELM_HISTORY_MAX").
+		Default(strconv.Itoa(int(Helm3HistoryMax))).
+		Int32Var(&Helm3HistoryMax)
+
+	cmd.Flag("helm-timeout", "Helm: time to wait for any individual Kubernetes operation (like Jobs for hooks).").
+		Envar("HELM_TIMEOUT").
+		Default(Helm3Timeout.String()).
+		DurationVar(&Helm3Timeout)
 
 	cmd.Flag("config-map", "Name of a ConfigMap to store values.").
 		Envar("ADDON_OPERATOR_CONFIG_MAP").

--- a/pkg/helm/client/client.go
+++ b/pkg/helm/client/client.go
@@ -1,0 +1,19 @@
+package client
+
+import "github.com/flant/addon-operator/pkg/utils"
+
+type HelmClient interface {
+	CommandEnv() []string
+	Cmd(args ...string) (string, string, error)
+	InitAndVersion() error
+	DeleteSingleFailedRevision(releaseName string) error
+	DeleteOldFailedRevisions(releaseName string) error
+	LastReleaseStatus(releaseName string) (string, string, error)
+	UpgradeRelease(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) error
+	Render(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) (string, error)
+	GetReleaseValues(releaseName string) (utils.Values, error)
+	DeleteRelease(releaseName string) error
+	ListReleases(labelSelector map[string]string) ([]string, error)
+	ListReleasesNames(labelSelector map[string]string) ([]string, error)
+	IsReleaseExists(releaseName string) (bool, error)
+}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -1,396 +1,58 @@
 package helm
 
 import (
-	"bytes"
 	"fmt"
-	"os"
-	"os/exec"
-	"regexp"
-	"sort"
-	"strconv"
-	"strings"
-
-	log "github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kblabels "k8s.io/apimachinery/pkg/labels"
+	"net/http"
 
 	"github.com/flant/addon-operator/pkg/app"
-	"github.com/flant/addon-operator/pkg/utils"
-	"github.com/flant/shell-operator/pkg/executor"
+	"github.com/flant/addon-operator/pkg/helm/client"
+	"github.com/flant/addon-operator/pkg/helm/helm2"
+	"github.com/flant/addon-operator/pkg/helm/helm3"
 	"github.com/flant/shell-operator/pkg/kube"
 )
 
-const HelmPath = "helm"
-
-type HelmClientFactory struct {
-	KubeClient kube.KubernetesClient
-}
-
-var clientFactory *HelmClientFactory
-
-func clientFactoryInstance() *HelmClientFactory {
-	if clientFactory == nil {
-		clientFactory = &HelmClientFactory{}
-	}
-	return clientFactory
-}
-
-func WithKubeClient(client kube.KubernetesClient) {
-	factory := clientFactoryInstance()
-	factory.KubeClient = client
-}
-
-type HelmClient interface {
-	TillerNamespace() string
-	CommandEnv() []string
-	Cmd(args ...string) (string, string, error)
-	InitAndVersion() error
-	DeleteSingleFailedRevision(releaseName string) error
-	DeleteOldFailedRevisions(releaseName string) error
-	LastReleaseStatus(releaseName string) (string, string, error)
-	UpgradeRelease(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) error
-	Render(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) (string, error)
-	GetReleaseValues(releaseName string) (utils.Values, error)
-	DeleteRelease(releaseName string) error
-	ListReleases(labelSelector map[string]string) ([]string, error)
-	ListReleasesNames(labelSelector map[string]string) ([]string, error)
-	IsReleaseExists(releaseName string) (bool, error)
-}
-
-var Client HelmClient
-
-type helmClient struct {
-	KubeClient kube.KubernetesClient
-	LogEntry   *log.Entry
-}
-
-var _ HelmClient = &helmClient{}
-
-var NewClient = func(logLabels ...map[string]string) HelmClient {
-	logEntry := log.WithField("operator.component", "helm")
-	if len(logLabels) > 0 {
-		logEntry = logEntry.WithFields(utils.LabelsToLogFields(logLabels[0]))
-	}
-
-	return &helmClient{
-		LogEntry:   logEntry,
-		KubeClient: clientFactoryInstance().KubeClient,
-	}
-}
-
-func (h *helmClient) WithKubeClient(client kube.KubernetesClient) {
-	h.KubeClient = client
-}
-
-func (h *helmClient) TillerNamespace() string {
-	return app.Namespace
-}
-
-func (h *helmClient) CommandEnv() []string {
-	res := make([]string, 0)
-	res = append(res, fmt.Sprintf("TILLER_NAMESPACE=%s", app.Namespace))
-	if TillerConnectAddress != "" {
-		res = append(res, fmt.Sprintf("HELM_HOST=%s", TillerConnectAddress))
-	}
-	return res
-}
-
-// Cmd starts Helm with specified arguments.
-// Sets the TILLER_NAMESPACE environment variable before starting, because Addon-operator works with its own Tiller.
-func (h *helmClient) Cmd(args ...string) (stdout string, stderr string, err error) {
-	cmd := exec.Command(HelmPath, args...)
-	cmd.Env = append(os.Environ(), h.CommandEnv()...)
-
-	var stdoutBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
-
-	err = executor.Run(cmd)
-	stdout = strings.TrimSpace(stdoutBuf.String())
-	stderr = strings.TrimSpace(stderrBuf.String())
-
-	return
-}
-
-// InitAndVersion runs helm init and helm version commands
-func (h *helmClient) InitAndVersion() error {
-	stdout, stderr, err := h.Cmd("init", "--client-only")
-	if err != nil {
-		return fmt.Errorf("helm init: %v\n%v %v", err, stdout, stderr)
-	}
-
-	stdout, stderr, err = h.Cmd("version", "--short", "--tiller-connection-timeout", fmt.Sprintf("%d", TillerWaitTimeoutSeconds))
-	if err != nil {
-		return fmt.Errorf("unable to get helm or tiller version: %v\n%v %v", err, stdout, stderr)
-	}
-	stdout = strings.Join([]string{stdout, stderr}, "\n")
-	stdout = strings.ReplaceAll(stdout, "\n", " ")
-	log.Infof("Helm successfully initialized. Version: %s", stdout)
-
+var NewClient = func(logLabels ...map[string]string) client.HelmClient {
 	return nil
 }
 
-func (h *helmClient) DeleteSingleFailedRevision(releaseName string) (err error) {
-	revision, status, err := h.LastReleaseStatus(releaseName)
+var HealthzHandler func(writer http.ResponseWriter, request *http.Request)
+
+func Init(client kube.KubernetesClient) error {
+	// Try helm3 first
+	err := helm3.Init(&helm3.Helm3Options{
+		Namespace:  app.Namespace,
+		HistoryMax: app.Helm3HistoryMax,
+		Timeout:    app.Helm3Timeout,
+		KubeClient: client,
+	})
+	if err == nil {
+		NewClient = helm3.NewClient
+		return nil
+	}
+
+	// Fallback to helm2
+	// TODO make tiller cancelable
+	err = helm2.InitTillerProcess(helm2.TillerOptions{
+		Namespace:          app.Namespace,
+		HistoryMax:         app.TillerMaxHistory,
+		ListenAddress:      app.TillerListenAddress,
+		ListenPort:         app.TillerListenPort,
+		ProbeListenAddress: app.TillerProbeListenAddress,
+		ProbeListenPort:    app.TillerProbeListenPort,
+	})
 	if err != nil {
-		if revision == "0" {
-			// Revision 0 is not an error. Just skips deletion.
-			log.Debugf("helm release '%s': Release not found, no cleanup required.", releaseName)
-			return nil
-		}
-		h.LogEntry.Errorf("helm release '%s': got error from LastReleaseStatus: %s", releaseName, err)
-		return err
+		return fmt.Errorf("init tiller: %s", err)
 	}
 
-	if revision == "1" && status == "FAILED" {
-		// Deletes and purges!
-		err = h.DeleteRelease(releaseName)
-		if err != nil {
-			h.LogEntry.Errorf("helm release '%s': cleanup of failed revision got error: %v", releaseName, err)
-			return err
-		}
-		h.LogEntry.Infof("helm release '%s': cleanup of failed revision succeeded", releaseName)
-	} else {
-		// No interest of revisions older than 1.
-		h.LogEntry.Debugf("helm release '%s': has revision '%s' with status %s", releaseName, revision, status)
-	}
-
-	return
-}
-
-func (h *helmClient) DeleteOldFailedRevisions(releaseName string) error {
-	cmNames, err := h.ListReleases(map[string]string{"STATUS": "FAILED", "NAME": releaseName})
+	// Initialize helm2 client
+	err = helm2.Init(&helm2.Helm2Options{
+		Namespace:  app.Namespace,
+		KubeClient: client,
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("init helm client: %s", err)
 	}
-
-	h.LogEntry.Debugf("helm release '%s': found ConfigMaps: %v", releaseName, cmNames)
-
-	var releaseCmNamePattern = regexp.MustCompile(`^(.*).v([0-9]+)$`)
-
-	revisions := make([]int, 0)
-	for _, cmName := range cmNames {
-		matchRes := releaseCmNamePattern.FindStringSubmatch(cmName)
-		if matchRes != nil {
-			revision, err := strconv.Atoi(matchRes[2])
-			if err != nil {
-				continue
-			}
-			revisions = append(revisions, revision)
-		}
-	}
-	sort.Ints(revisions)
-
-	// Do not removes last FAILED revision.
-	if len(revisions) > 0 {
-		revisions = revisions[:len(revisions)-1]
-	}
-
-	for _, revision := range revisions {
-		cmName := fmt.Sprintf("%s.v%d", releaseName, revision)
-		h.LogEntry.Infof("helm release '%s': delete old FAILED revision cm/%s", releaseName, cmName)
-
-		err := h.KubeClient.CoreV1().
-			ConfigMaps(app.Namespace).
-			Delete(cmName, &metav1.DeleteOptions{})
-
-		if err != nil {
-			return err
-		}
-	}
-
+	NewClient = helm2.NewClient
+	HealthzHandler = helm2.TillerHealthHandler()
 	return nil
-}
-
-// TODO get this info from cm
-// Get last known revision and status
-// helm history output:
-// REVISION	UPDATED                 	STATUS    	CHART                 	DESCRIPTION
-// 1        Fri Jul 14 18:25:00 2017	SUPERSEDED	symfony-demo-0.1.0    	Install complete
-func (h *helmClient) LastReleaseStatus(releaseName string) (revision string, status string, err error) {
-	stdout, stderr, err := h.Cmd("history", releaseName, "--max", "1")
-
-	if err != nil {
-		errLine := strings.Split(stderr, "\n")[0]
-		if strings.Contains(errLine, "Error:") && strings.Contains(errLine, "not found") {
-			// Bad module name or no releases installed
-			err = fmt.Errorf("release '%s' not found\n%v %v", releaseName, stdout, stderr)
-			revision = "0"
-			return
-		}
-
-		err = fmt.Errorf("cannot get history for release '%s'\n%v %v", releaseName, stdout, stderr)
-		return
-	}
-
-	historyLines := strings.Split(stdout, "\n")
-	lastLine := historyLines[len(historyLines)-1]
-	fields := strings.SplitN(lastLine, "\t", 5) //regexp.MustCompile("\\t").Split(lastLine, 5)
-	revision = strings.TrimSpace(fields[0])
-	status = strings.TrimSpace(fields[2])
-	return
-}
-
-func (h *helmClient) UpgradeRelease(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) error {
-	args := make([]string, 0)
-	args = append(args, "upgrade")
-	args = append(args, "--install")
-	args = append(args, releaseName)
-	args = append(args, chart)
-
-	if namespace != "" {
-		args = append(args, "--namespace")
-		args = append(args, namespace)
-	}
-
-	for _, valuesPath := range valuesPaths {
-		args = append(args, "--values")
-		args = append(args, valuesPath)
-	}
-
-	for _, setValue := range setValues {
-		args = append(args, "--set")
-		args = append(args, setValue)
-	}
-
-	h.LogEntry.Infof("Running helm upgrade for release '%s' with chart '%s' in namespace '%s' ...", releaseName, chart, namespace)
-	stdout, stderr, err := h.Cmd(args...)
-	if err != nil {
-		return fmt.Errorf("helm upgrade failed: %s:\n%s %s", err, stdout, stderr)
-	}
-	h.LogEntry.Infof("Helm upgrade for release '%s' with chart '%s' in namespace '%s' successful:\n%s\n%s", releaseName, chart, namespace, stdout, stderr)
-
-	return nil
-}
-
-func (h *helmClient) GetReleaseValues(releaseName string) (utils.Values, error) {
-	stdout, stderr, err := h.Cmd("get", "values", releaseName)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get values of helm release %s: %s\n%s %s", releaseName, err, stdout, stderr)
-	}
-
-	values, err := utils.NewValuesFromBytes([]byte(stdout))
-	if err != nil {
-		return nil, fmt.Errorf("cannot get values of helm release %s: %s", releaseName, err)
-	}
-
-	return values, nil
-}
-
-func (h *helmClient) DeleteRelease(releaseName string) (err error) {
-	h.LogEntry.Debugf("helm release '%s': execute helm delete --purge", releaseName)
-
-	stdout, stderr, err := h.Cmd("delete", "--purge", releaseName)
-	if err != nil {
-		return fmt.Errorf("helm delete --purge %s invocation error: %v\n%v %v", releaseName, err, stdout, stderr)
-	}
-
-	return
-}
-
-func (h *helmClient) IsReleaseExists(releaseName string) (bool, error) {
-	revision, _, err := h.LastReleaseStatus(releaseName)
-	if err != nil && revision == "0" {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
-}
-
-// Returns all known releases as strings — "<release_name>.v<release_number>"
-// Helm looks for ConfigMaps by label 'OWNER=TILLER' and gets release info from the 'release' key.
-// https://github.com/kubernetes/helm/blob/8981575082ea6fc2a670f81fb6ca5b560c4f36a7/pkg/storage/driver/cfgmaps.go#L88
-func (h *helmClient) ListReleases(labelSelector map[string]string) ([]string, error) {
-	labelsSet := make(kblabels.Set)
-	for k, v := range labelSelector {
-		labelsSet[k] = v
-	}
-	labelsSet["OWNER"] = "TILLER"
-
-	cmList, err := h.KubeClient.CoreV1().
-		ConfigMaps(app.Namespace).
-		List(metav1.ListOptions{LabelSelector: labelsSet.AsSelector().String()})
-	if err != nil {
-		h.LogEntry.Debugf("helm: list of releases ConfigMaps failed: %s", err)
-		return nil, err
-	}
-
-	releases := make([]string, 0)
-	for _, cm := range cmList.Items {
-		if _, has_key := cm.Data["release"]; has_key {
-			releases = append(releases, cm.Name)
-		}
-	}
-
-	sort.Strings(releases)
-
-	return releases, nil
-}
-
-// ListReleasesNames returns list of release names without suffixes ".v<release_number>"
-func (h *helmClient) ListReleasesNames(labelSelector map[string]string) ([]string, error) {
-	// Get all release names
-	releases, err := h.ListReleases(labelSelector)
-	if err != nil {
-		return []string{}, err
-	}
-
-	var releaseNameRegex = regexp.MustCompile(`^(.*).v[0-9]+$`)
-
-	// Drop .v* suffix and make array of unique names
-	uniqNamesMap := map[string]bool{}
-	for _, release := range releases {
-		matchRes := releaseNameRegex.FindStringSubmatch(release)
-		if matchRes != nil {
-			releaseName := matchRes[1]
-			uniqNamesMap[releaseName] = true
-		}
-	}
-
-	uniqNames := make([]string, 0)
-	for name := range uniqNamesMap {
-		uniqNames = append(uniqNames, name)
-	}
-
-	return uniqNames, nil
-}
-
-// ListReleasesNames returns list of release names without suffixes ".v<release_number>"
-func (h *helmClient) Render(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) (string, error) {
-	args := make([]string, 0)
-	args = append(args, "template")
-	args = append(args, chart)
-
-	// Release name
-	if releaseName != "" {
-		args = append(args, "--name")
-		args = append(args, releaseName)
-	}
-
-	if namespace != "" {
-		args = append(args, "--namespace")
-		args = append(args, namespace)
-	}
-
-	for _, valuesPath := range valuesPaths {
-		args = append(args, "--values")
-		args = append(args, valuesPath)
-	}
-
-	for _, setValue := range setValues {
-		args = append(args, "--set")
-		args = append(args, setValue)
-	}
-
-	h.LogEntry.Debugf("Render helm templates for chart '%s' in namespace '%s' ...", chart, namespace)
-	stdout, stderr, err := h.Cmd(args...)
-	if err != nil {
-		return "", fmt.Errorf("helm upgrade failed: %s:\n%s %s", err, stdout, stderr)
-	}
-	h.LogEntry.Infof("Render helm templates for chart '%s' was successful", chart)
-
-	return stdout, nil
 }

--- a/pkg/helm/helm2/helm2.go
+++ b/pkg/helm/helm2/helm2.go
@@ -1,0 +1,376 @@
+package helm2
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kblabels "k8s.io/apimachinery/pkg/labels"
+
+	"github.com/flant/addon-operator/pkg/helm/client"
+	"github.com/flant/addon-operator/pkg/utils"
+	"github.com/flant/shell-operator/pkg/executor"
+	"github.com/flant/shell-operator/pkg/kube"
+)
+
+const Helm2Path = "helm"
+
+type Helm2Options struct {
+	Namespace  string
+	KubeClient kube.KubernetesClient
+}
+
+var HelmOptions *Helm2Options
+
+func Init(options *Helm2Options) error {
+	hc := &Helm2Client{
+		LogEntry: log.WithField("operator.component", "helm"),
+	}
+	err := hc.InitAndVersion()
+	if err != nil {
+		return err
+	}
+	HelmOptions = options
+	return nil
+}
+
+type Helm2Client struct {
+	KubeClient kube.KubernetesClient
+	LogEntry   *log.Entry
+	Namespace  string
+}
+
+var _ client.HelmClient = &Helm2Client{}
+
+func NewClient(logLabels ...map[string]string) client.HelmClient {
+	logEntry := log.WithField("operator.component", "helm")
+	if len(logLabels) > 0 {
+		logEntry = logEntry.WithFields(utils.LabelsToLogFields(logLabels[0]))
+	}
+
+	return &Helm2Client{
+		LogEntry:   logEntry,
+		KubeClient: HelmOptions.KubeClient,
+		Namespace:  HelmOptions.Namespace,
+	}
+}
+
+func (h *Helm2Client) WithKubeClient(client kube.KubernetesClient) {
+	h.KubeClient = client
+}
+
+func (h *Helm2Client) CommandEnv() []string {
+	res := make([]string, 0)
+	res = append(res, fmt.Sprintf("TILLER_NAMESPACE=%s", h.Namespace))
+	if TillerConnectAddress != "" {
+		res = append(res, fmt.Sprintf("HELM_HOST=%s", TillerConnectAddress))
+	}
+	return res
+}
+
+// Cmd starts Helm with specified arguments.
+// Sets the TILLER_NAMESPACE environment variable before starting, because Addon-operator works with its own Tiller.
+func (h *Helm2Client) Cmd(args ...string) (stdout string, stderr string, err error) {
+	cmd := exec.Command(Helm2Path, args...)
+	cmd.Env = append(os.Environ(), h.CommandEnv()...)
+
+	var stdoutBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	err = executor.Run(cmd)
+	stdout = strings.TrimSpace(stdoutBuf.String())
+	stderr = strings.TrimSpace(stderrBuf.String())
+
+	return
+}
+
+// InitAndVersion runs helm init and helm version commands
+func (h *Helm2Client) InitAndVersion() error {
+	stdout, stderr, err := h.Cmd("init", "--client-only")
+	if err != nil {
+		return fmt.Errorf("helm init: %v\n%v %v", err, stdout, stderr)
+	}
+
+	stdout, stderr, err = h.Cmd("version", "--short", "--tiller-connection-timeout", fmt.Sprintf("%d", TillerWaitTimeoutSeconds))
+	if err != nil {
+		return fmt.Errorf("unable to get helm or tiller version: %v\n%v %v", err, stdout, stderr)
+	}
+	stdout = strings.Join([]string{stdout, stderr}, "\n")
+	stdout = strings.ReplaceAll(stdout, "\n", " ")
+	log.Infof("Helm successfully initialized. Version: %s", stdout)
+
+	return nil
+}
+
+func (h *Helm2Client) DeleteSingleFailedRevision(releaseName string) (err error) {
+	revision, status, err := h.LastReleaseStatus(releaseName)
+	if err != nil {
+		if revision == "0" {
+			// Revision 0 is not an error. Just skips deletion.
+			log.Debugf("helm release '%s': Release not found, no cleanup required.", releaseName)
+			return nil
+		}
+		h.LogEntry.Errorf("helm release '%s': got error from LastReleaseStatus: %s", releaseName, err)
+		return err
+	}
+
+	if revision == "1" && status == "FAILED" {
+		// Deletes and purges!
+		err = h.DeleteRelease(releaseName)
+		if err != nil {
+			h.LogEntry.Errorf("helm release '%s': cleanup of failed revision got error: %v", releaseName, err)
+			return err
+		}
+		h.LogEntry.Infof("helm release '%s': cleanup of failed revision succeeded", releaseName)
+	} else {
+		// No interest of revisions older than 1.
+		h.LogEntry.Debugf("helm release '%s': has revision '%s' with status %s", releaseName, revision, status)
+	}
+
+	return
+}
+
+func (h *Helm2Client) DeleteOldFailedRevisions(releaseName string) error {
+	cmNames, err := h.ListReleases(map[string]string{"STATUS": "FAILED", "NAME": releaseName})
+	if err != nil {
+		return err
+	}
+
+	h.LogEntry.Debugf("helm release '%s': found ConfigMaps: %v", releaseName, cmNames)
+
+	var releaseCmNamePattern = regexp.MustCompile(`^(.*).v([0-9]+)$`)
+
+	revisions := make([]int, 0)
+	for _, cmName := range cmNames {
+		matchRes := releaseCmNamePattern.FindStringSubmatch(cmName)
+		if matchRes != nil {
+			revision, err := strconv.Atoi(matchRes[2])
+			if err != nil {
+				continue
+			}
+			revisions = append(revisions, revision)
+		}
+	}
+	sort.Ints(revisions)
+
+	// Do not removes last FAILED revision.
+	if len(revisions) > 0 {
+		revisions = revisions[:len(revisions)-1]
+	}
+
+	for _, revision := range revisions {
+		cmName := fmt.Sprintf("%s.v%d", releaseName, revision)
+		h.LogEntry.Infof("helm release '%s': delete old FAILED revision cm/%s", releaseName, cmName)
+
+		err := h.KubeClient.CoreV1().
+			ConfigMaps(h.Namespace).
+			Delete(cmName, &metav1.DeleteOptions{})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// TODO get this info from cm
+// Get last known revision and status
+// helm history output:
+// REVISION	UPDATED                 	STATUS    	CHART                 	DESCRIPTION
+// 1        Fri Jul 14 18:25:00 2017	SUPERSEDED	symfony-demo-0.1.0    	Install complete
+func (h *Helm2Client) LastReleaseStatus(releaseName string) (revision string, status string, err error) {
+	stdout, stderr, err := h.Cmd("history", releaseName, "--max", "1")
+
+	if err != nil {
+		errLine := strings.Split(stderr, "\n")[0]
+		if strings.Contains(errLine, "Error:") && strings.Contains(errLine, "not found") {
+			// Bad module name or no releases installed
+			err = fmt.Errorf("release '%s' not found\n%v %v", releaseName, stdout, stderr)
+			revision = "0"
+			return
+		}
+
+		err = fmt.Errorf("cannot get history for release '%s'\n%v %v", releaseName, stdout, stderr)
+		return
+	}
+
+	historyLines := strings.Split(stdout, "\n")
+	lastLine := historyLines[len(historyLines)-1]
+	fields := strings.SplitN(lastLine, "\t", 5) //regexp.MustCompile("\\t").Split(lastLine, 5)
+	revision = strings.TrimSpace(fields[0])
+	status = strings.TrimSpace(fields[2])
+	return
+}
+
+func (h *Helm2Client) UpgradeRelease(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) error {
+	args := make([]string, 0)
+	args = append(args, "upgrade")
+	args = append(args, "--install")
+	args = append(args, releaseName)
+	args = append(args, chart)
+
+	if namespace != "" {
+		args = append(args, "--namespace")
+		args = append(args, namespace)
+	}
+
+	for _, valuesPath := range valuesPaths {
+		args = append(args, "--values")
+		args = append(args, valuesPath)
+	}
+
+	for _, setValue := range setValues {
+		args = append(args, "--set")
+		args = append(args, setValue)
+	}
+
+	h.LogEntry.Infof("Running helm upgrade for release '%s' with chart '%s' in namespace '%s' ...", releaseName, chart, namespace)
+	stdout, stderr, err := h.Cmd(args...)
+	if err != nil {
+		return fmt.Errorf("helm upgrade failed: %s:\n%s %s", err, stdout, stderr)
+	}
+	h.LogEntry.Infof("Helm upgrade for release '%s' with chart '%s' in namespace '%s' successful:\n%s\n%s", releaseName, chart, namespace, stdout, stderr)
+
+	return nil
+}
+
+func (h *Helm2Client) GetReleaseValues(releaseName string) (utils.Values, error) {
+	stdout, stderr, err := h.Cmd("get", "values", releaseName)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get values of helm release %s: %s\n%s %s", releaseName, err, stdout, stderr)
+	}
+
+	values, err := utils.NewValuesFromBytes([]byte(stdout))
+	if err != nil {
+		return nil, fmt.Errorf("cannot get values of helm release %s: %s", releaseName, err)
+	}
+
+	return values, nil
+}
+
+func (h *Helm2Client) DeleteRelease(releaseName string) (err error) {
+	h.LogEntry.Debugf("helm release '%s': execute helm delete --purge", releaseName)
+
+	stdout, stderr, err := h.Cmd("delete", "--purge", releaseName)
+	if err != nil {
+		return fmt.Errorf("helm delete --purge %s invocation error: %v\n%v %v", releaseName, err, stdout, stderr)
+	}
+
+	return
+}
+
+func (h *Helm2Client) IsReleaseExists(releaseName string) (bool, error) {
+	revision, _, err := h.LastReleaseStatus(releaseName)
+	if err != nil && revision == "0" {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// Returns all known releases as strings — "<release_name>.v<release_number>"
+// Helm looks for ConfigMaps by label 'OWNER=TILLER' and gets release info from the 'release' key.
+// https://github.com/kubernetes/helm/blob/8981575082ea6fc2a670f81fb6ca5b560c4f36a7/pkg/storage/driver/cfgmaps.go#L88
+func (h *Helm2Client) ListReleases(labelSelector map[string]string) ([]string, error) {
+	labelsSet := make(kblabels.Set)
+	for k, v := range labelSelector {
+		labelsSet[k] = v
+	}
+	labelsSet["OWNER"] = "TILLER"
+
+	cmList, err := h.KubeClient.CoreV1().
+		ConfigMaps(h.Namespace).
+		List(metav1.ListOptions{LabelSelector: labelsSet.AsSelector().String()})
+	if err != nil {
+		h.LogEntry.Debugf("helm: list of releases ConfigMaps failed: %s", err)
+		return nil, err
+	}
+
+	releases := make([]string, 0)
+	for _, cm := range cmList.Items {
+		if _, has_key := cm.Data["release"]; has_key {
+			releases = append(releases, cm.Name)
+		}
+	}
+
+	sort.Strings(releases)
+
+	return releases, nil
+}
+
+// ListReleasesNames returns list of release names without suffixes ".v<release_number>"
+func (h *Helm2Client) ListReleasesNames(labelSelector map[string]string) ([]string, error) {
+	// Get all release names
+	releases, err := h.ListReleases(labelSelector)
+	if err != nil {
+		return []string{}, err
+	}
+
+	var releaseNameRegex = regexp.MustCompile(`^(.*).v[0-9]+$`)
+
+	// Drop .v* suffix and make array of unique names
+	uniqNamesMap := map[string]bool{}
+	for _, release := range releases {
+		matchRes := releaseNameRegex.FindStringSubmatch(release)
+		if matchRes != nil {
+			releaseName := matchRes[1]
+			uniqNamesMap[releaseName] = true
+		}
+	}
+
+	uniqNames := make([]string, 0)
+	for name := range uniqNamesMap {
+		uniqNames = append(uniqNames, name)
+	}
+
+	return uniqNames, nil
+}
+
+// ListReleasesNames returns list of release names without suffixes ".v<release_number>"
+func (h *Helm2Client) Render(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) (string, error) {
+	args := make([]string, 0)
+	args = append(args, "template")
+	args = append(args, chart)
+
+	// Release name
+	if releaseName != "" {
+		args = append(args, "--name")
+		args = append(args, releaseName)
+	}
+
+	if namespace != "" {
+		args = append(args, "--namespace")
+		args = append(args, namespace)
+	}
+
+	for _, valuesPath := range valuesPaths {
+		args = append(args, "--values")
+		args = append(args, valuesPath)
+	}
+
+	for _, setValue := range setValues {
+		args = append(args, "--set")
+		args = append(args, setValue)
+	}
+
+	h.LogEntry.Debugf("Render helm templates for chart '%s' in namespace '%s' ...", chart, namespace)
+	stdout, stderr, err := h.Cmd(args...)
+	if err != nil {
+		return "", fmt.Errorf("helm upgrade failed: %s:\n%s %s", err, stdout, stderr)
+	}
+	h.LogEntry.Infof("Render helm templates for chart '%s' was successful", chart)
+
+	return stdout, nil
+}

--- a/pkg/helm/helm2/tiller.go
+++ b/pkg/helm/helm2/tiller.go
@@ -1,4 +1,4 @@
-package helm
+package helm2
 
 import (
 	"bufio"
@@ -96,7 +96,7 @@ func WaitTillerReady(addr string, logEntry *log.Entry) error {
 
 	retries := 0
 	for {
-		cliHelm := &helmClient{}
+		cliHelm := &Helm2Client{}
 		stdout, stderr, err := cliHelm.Cmd("version", "--tiller-connection-timeout", fmt.Sprintf("%d", TillerWaitTimeoutSeconds))
 
 		if err != nil {

--- a/pkg/helm/helm3/helm3.go
+++ b/pkg/helm/helm3/helm3.go
@@ -1,0 +1,325 @@
+package helm3
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kblabels "k8s.io/apimachinery/pkg/labels"
+	k8syaml "sigs.k8s.io/yaml"
+
+	"github.com/flant/addon-operator/pkg/helm/client"
+	"github.com/flant/addon-operator/pkg/utils"
+	"github.com/flant/shell-operator/pkg/executor"
+	"github.com/flant/shell-operator/pkg/kube"
+)
+
+const Helm3Path = "helm"
+
+type Helm3Options struct {
+	Namespace  string
+	HistoryMax int32
+	Timeout    time.Duration
+	KubeClient kube.KubernetesClient
+}
+
+var Options *Helm3Options
+
+// Init runs
+func Init(options *Helm3Options) error {
+	hc := &Helm3Client{
+		LogEntry: log.WithField("operator.component", "helm"),
+	}
+	err := hc.InitAndVersion()
+	if err != nil {
+		return err
+	}
+	Options = options
+	return nil
+}
+
+type Helm3Client struct {
+	KubeClient kube.KubernetesClient
+	LogEntry   *log.Entry
+	Namespace  string
+}
+
+var _ client.HelmClient = &Helm3Client{}
+
+func NewClient(logLabels ...map[string]string) client.HelmClient {
+	logEntry := log.WithField("operator.component", "helm")
+	if len(logLabels) > 0 {
+		logEntry = logEntry.WithFields(utils.LabelsToLogFields(logLabels[0]))
+	}
+
+	return &Helm3Client{
+		LogEntry:   logEntry,
+		KubeClient: Options.KubeClient,
+		Namespace:  Options.Namespace,
+	}
+}
+
+func (h *Helm3Client) WithKubeClient(client kube.KubernetesClient) {
+	h.KubeClient = client
+}
+
+func (h *Helm3Client) CommandEnv() []string {
+	res := make([]string, 0)
+	return res
+}
+
+// Cmd starts Helm with specified arguments.
+// Sets the TILLER_NAMESPACE environment variable before starting, because Addon-operator works with its own Tiller.
+func (h *Helm3Client) Cmd(args ...string) (stdout string, stderr string, err error) {
+	cmd := exec.Command(Helm3Path, args...)
+	cmd.Env = append(os.Environ(), h.CommandEnv()...)
+
+	var stdoutBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	err = executor.Run(cmd)
+	stdout = strings.TrimSpace(stdoutBuf.String())
+	stderr = strings.TrimSpace(stderrBuf.String())
+
+	return
+}
+
+// InitAndVersion runs helm version command.
+func (h *Helm3Client) InitAndVersion() error {
+	stdout, stderr, err := h.Cmd("version", "--short")
+	if err != nil {
+		return fmt.Errorf("unable to get helm version: %v\n%v %v", err, stdout, stderr)
+	}
+	stdout = strings.Join([]string{stdout, stderr}, "\n")
+	stdout = strings.ReplaceAll(stdout, "\n", " ")
+	log.Infof("Helm 3 version: %s", stdout)
+
+	return nil
+}
+
+func (h *Helm3Client) DeleteSingleFailedRevision(releaseName string) error {
+	// No need to delete single failed revision anymore
+	// https://github.com/helm/helm/issues/8037#issuecomment-622217632
+	return nil
+}
+
+func (h *Helm3Client) DeleteOldFailedRevisions(releaseName string) error {
+	// No need to delete single failed revision anymore
+	// https://github.com/helm/helm/issues/8037#issuecomment-622217632
+	return nil
+}
+
+// LastReleaseStatus returns last known revision for release and its status
+//   Example helm history output:
+//   REVISION	UPDATED                 	STATUS    	CHART                 	DESCRIPTION
+//   1        Fri Jul 14 18:25:00 2017	SUPERSEDED	symfony-demo-0.1.0    	Install complete
+func (h *Helm3Client) LastReleaseStatus(releaseName string) (revision string, status string, err error) {
+	stdout, stderr, err := h.Cmd("history", releaseName, "--max", "1", "--output", "yaml")
+
+	if err != nil {
+		errLine := strings.Split(stderr, "\n")[0]
+		if strings.Contains(errLine, "Error:") && strings.Contains(errLine, "not found") {
+			// Bad module name or no releases installed
+			err = fmt.Errorf("release '%s' not found\n%v %v", releaseName, stdout, stderr)
+			revision = "0"
+			return
+		}
+
+		err = fmt.Errorf("cannot get history for release '%s'\n%v %v", releaseName, stdout, stderr)
+		return
+	}
+
+	var historyInfo []map[string]string
+
+	err = k8syaml.Unmarshal([]byte(stdout), &historyInfo)
+	if err != nil {
+		return "", "", fmt.Errorf("helm history returns invalid json: %v", err)
+	}
+	if len(historyInfo) == 0 {
+		return "", "", fmt.Errorf("helm history is empty: '%s'", stdout)
+	}
+	status, has := historyInfo[0]["status"]
+	if !has {
+		return "", "", fmt.Errorf("helm history has no 'status' field: '%s'", stdout)
+	}
+	revision, has = historyInfo[0]["revision"]
+	if !has {
+		return "", "", fmt.Errorf("helm history has no 'revision' field: '%s'", stdout)
+	}
+	return
+}
+
+func (h *Helm3Client) UpgradeRelease(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) error {
+	args := make([]string, 0)
+	args = append(args, "upgrade")
+	// releaseName and chart path are positional arguments, put them first.
+	args = append(args, releaseName)
+	args = append(args, chart)
+
+	// Flags for upgrade command.
+	args = append(args, "--install")
+
+	args = append(args, "--history-max")
+	args = append(args, fmt.Sprintf("%d", Options.HistoryMax))
+
+	args = append(args, "--timeout")
+	args = append(args, Options.Timeout.String())
+
+	if namespace != "" {
+		args = append(args, "--namespace")
+		args = append(args, namespace)
+	}
+
+	for _, valuesPath := range valuesPaths {
+		args = append(args, "--values")
+		args = append(args, valuesPath)
+	}
+
+	for _, setValue := range setValues {
+		args = append(args, "--set")
+		args = append(args, setValue)
+	}
+
+	h.LogEntry.Infof("Running helm upgrade for release '%s' with chart '%s' in namespace '%s' ...", releaseName, chart, namespace)
+	stdout, stderr, err := h.Cmd(args...)
+	if err != nil {
+		return fmt.Errorf("helm upgrade failed: %s:\n%s %s", err, stdout, stderr)
+	}
+	h.LogEntry.Infof("Helm upgrade for release '%s' with chart '%s' in namespace '%s' successful:\n%s\n%s", releaseName, chart, namespace, stdout, stderr)
+
+	return nil
+}
+
+func (h *Helm3Client) GetReleaseValues(releaseName string) (utils.Values, error) {
+	args := make([]string, 0)
+	args = append(args, "get")
+	args = append(args, "values")
+	args = append(args, releaseName)
+
+	args = append(args, "--namespace")
+	args = append(args, h.Namespace)
+
+	args = append(args, "--output")
+	args = append(args, "yaml")
+
+	stdout, stderr, err := h.Cmd(args...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get values of helm release %s: %s\n%s %s", releaseName, err, stdout, stderr)
+	}
+
+	values, err := utils.NewValuesFromBytes([]byte(stdout))
+	if err != nil {
+		return nil, fmt.Errorf("cannot get values of helm release %s: %s", releaseName, err)
+	}
+
+	return values, nil
+}
+
+func (h *Helm3Client) DeleteRelease(releaseName string) (err error) {
+	h.LogEntry.Debugf("helm release '%s': execute helm uninstall", releaseName)
+
+	args := make([]string, 0)
+	args = append(args, "uninstall")
+	args = append(args, releaseName)
+
+	args = append(args, "--namespace")
+	args = append(args, h.Namespace)
+
+	stdout, stderr, err := h.Cmd(args...)
+	if err != nil {
+		return fmt.Errorf("helm uninstall %s invocation error: %v\n%v %v", releaseName, err, stdout, stderr)
+	}
+
+	return
+}
+
+func (h *Helm3Client) IsReleaseExists(releaseName string) (bool, error) {
+	revision, _, err := h.LastReleaseStatus(releaseName)
+	if err != nil && revision == "0" {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// ListReleases returns all known releases as strings — "<release_name>.v<release_number>"
+// It is required only for helm2.
+func (h *Helm3Client) ListReleases(labelSelector map[string]string) (releases []string, err error) {
+	return
+}
+
+// ListReleasesNames returns list of release names.
+// Names are extracted from label "name" in Secrets with label "owner"=="helm".
+func (h *Helm3Client) ListReleasesNames(labelSelector map[string]string) ([]string, error) {
+	labelsSet := make(kblabels.Set)
+	for k, v := range labelSelector {
+		labelsSet[k] = v
+	}
+	labelsSet["owner"] = "helm"
+
+	list, err := h.KubeClient.CoreV1().
+		Secrets(h.Namespace).
+		List(metav1.ListOptions{LabelSelector: labelsSet.AsSelector().String()})
+	if err != nil {
+		h.LogEntry.Debugf("helm: list of releases ConfigMaps failed: %s", err)
+		return nil, err
+	}
+
+	uniqNamesMap := make(map[string]struct{})
+	for _, secret := range list.Items {
+		releaseName, has_key := secret.Labels["name"]
+		if has_key && releaseName != "" {
+			uniqNamesMap[releaseName] = struct{}{}
+		}
+	}
+
+	uniqNames := make([]string, 0)
+	for name := range uniqNamesMap {
+		uniqNames = append(uniqNames, name)
+	}
+
+	sort.Strings(uniqNames)
+	return uniqNames, nil
+}
+
+// ListReleasesNames returns list of release names without suffixes ".v<release_number>"
+func (h *Helm3Client) Render(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) (string, error) {
+	args := make([]string, 0)
+	args = append(args, "template")
+	args = append(args, releaseName)
+	args = append(args, chart)
+
+	if namespace != "" {
+		args = append(args, "--namespace")
+		args = append(args, namespace)
+	}
+
+	for _, valuesPath := range valuesPaths {
+		args = append(args, "--values")
+		args = append(args, valuesPath)
+	}
+
+	for _, setValue := range setValues {
+		args = append(args, "--set")
+		args = append(args, setValue)
+	}
+
+	h.LogEntry.Debugf("Render helm templates for chart '%s' in namespace '%s' ...", chart, namespace)
+	stdout, stderr, err := h.Cmd(args...)
+	if err != nil {
+		return "", fmt.Errorf("helm upgrade failed: %s:\n%s %s", err, stdout, stderr)
+	}
+	h.LogEntry.Infof("Render helm templates for chart '%s' was successful", chart)
+
+	return stdout, nil
+}

--- a/pkg/helm/helm_mock.go
+++ b/pkg/helm/helm_mock.go
@@ -2,10 +2,13 @@
 
 package helm
 
-import "github.com/flant/addon-operator/pkg/utils"
+import (
+	"github.com/flant/addon-operator/pkg/helm/client"
+	"github.com/flant/addon-operator/pkg/utils"
+)
 
 type MockHelmClient struct {
-	HelmClient
+	client.HelmClient
 	DeleteSingleFailedRevisionExecuted bool
 	UpgradeReleaseExecuted             bool
 	DeleteReleaseExecuted              bool
@@ -32,10 +35,6 @@ func (h *MockHelmClient) ListReleasesNames(_ map[string]string) ([]string, error
 
 func (h *MockHelmClient) CommandEnv() []string {
 	return []string{}
-}
-
-func (h *MockHelmClient) TillerNamespace() string {
-	return "addon-operator"
 }
 
 func (h *MockHelmClient) DeleteSingleFailedRevision(_ string) error {

--- a/pkg/helm_resources_manager/helm_resources_manager.go
+++ b/pkg/helm_resources_manager/helm_resources_manager.go
@@ -25,6 +25,7 @@ type HelmResourcesManager interface {
 	PauseMonitor(moduleName string)
 	ResumeMonitor(moduleName string)
 	AbsentResources(moduleName string) ([]manifest.Manifest, error)
+	GetMonitor(moduleName string) *ResourcesMonitor
 	GetAbsentResources(templates []manifest.Manifest, defaultNamespace string) ([]manifest.Manifest, error)
 	Ch() chan AbsentResourcesEvent
 }
@@ -74,6 +75,7 @@ func (hm *helmResourcesManager) Ch() chan AbsentResourcesEvent {
 }
 
 func (hm *helmResourcesManager) StartMonitor(moduleName string, manifests []manifest.Manifest, defaultNamespace string) {
+	log.Debugf("Start helm resources monitor for '%s'", moduleName)
 	hm.StopMonitor(moduleName)
 
 	rm := NewResourcesMonitor()
@@ -146,6 +148,10 @@ func (hm *helmResourcesManager) AbsentResources(moduleName string) ([]manifest.M
 		return monitor.AbsentResources()
 	}
 	return nil, nil
+}
+
+func (hm *helmResourcesManager) GetMonitor(moduleName string) *ResourcesMonitor {
+	return hm.monitors[moduleName]
 }
 
 func (hm *helmResourcesManager) GetAbsentResources(manifests []manifest.Manifest, defaultNamespace string) ([]manifest.Manifest, error) {

--- a/pkg/helm_resources_manager/resources_monitor.go
+++ b/pkg/helm_resources_manager/resources_monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sort"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -168,4 +169,17 @@ func (r *ResourcesMonitor) AbsentResources() ([]manifest.Manifest, error) {
 	}
 
 	return res, nil
+}
+
+func (r *ResourcesMonitor) ResourceIds() []string {
+	res := make([]string, 0)
+
+	for _, m := range r.manifests {
+		id := fmt.Sprintf("%s/%s/%s", m.Namespace(r.defaultNamespace), m.Kind(), m.Name())
+		res = append(res, id)
+	}
+
+	sort.Strings(res)
+
+	return res
 }

--- a/pkg/module_manager/module_manager_test.go
+++ b/pkg/module_manager/module_manager_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm"
+	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/kube_config_manager"
 	"github.com/flant/addon-operator/pkg/utils"
 	"github.com/flant/shell-operator/pkg/kube"
@@ -470,7 +471,7 @@ func Test_MainModuleManager_Get_Module(t *testing.T) {
 //}
 
 func Test_MainModuleManager_Get_ModuleHooksInOrder(t *testing.T) {
-	helm.NewClient = func(logLabels ...map[string]string) helm.HelmClient {
+	helm.NewClient = func(logLabels ...map[string]string) client.HelmClient {
 		return &helm.MockHelmClient{}
 	}
 	mm := NewMainModuleManager()
@@ -548,7 +549,7 @@ func Test_MainModuleManager_RunModule(t *testing.T) {
 	t.SkipNow()
 	hc := &helm.MockHelmClient{}
 
-	helm.NewClient = func(logLabels ...map[string]string) helm.HelmClient {
+	helm.NewClient = func(logLabels ...map[string]string) client.HelmClient {
 		return hc
 	}
 
@@ -600,7 +601,7 @@ func Test_MainModuleManager_DeleteModule(t *testing.T) {
 	t.SkipNow()
 	hc := &helm.MockHelmClient{}
 
-	helm.NewClient = func(logLabels ...map[string]string) helm.HelmClient {
+	helm.NewClient = func(logLabels ...map[string]string) client.HelmClient {
 		return hc
 	}
 
@@ -647,7 +648,7 @@ func Test_MainModuleManager_DeleteModule(t *testing.T) {
 func Test_MainModuleManager_RunModuleHook(t *testing.T) {
 	// TODO hooks not found
 	t.SkipNow()
-	helm.NewClient = func(logLabels ...map[string]string) helm.HelmClient {
+	helm.NewClient = func(logLabels ...map[string]string) client.HelmClient {
 		return &helm.MockHelmClient{}
 	}
 	mm := NewMainModuleManager()
@@ -960,7 +961,7 @@ func Test_MainModuleManager_RunModuleHook(t *testing.T) {
 //}
 
 func Test_MainModuleManager_Get_GlobalHooksInOrder(t *testing.T) {
-	helm.NewClient = func(logLabels ...map[string]string) helm.HelmClient {
+	helm.NewClient = func(logLabels ...map[string]string) client.HelmClient {
 		return &helm.MockHelmClient{}
 	}
 	mm := NewMainModuleManager()
@@ -997,7 +998,7 @@ func Test_MainModuleManager_Get_GlobalHooksInOrder(t *testing.T) {
 }
 
 func Test_MainModuleManager_Run_GlobalHook(t *testing.T) {
-	helm.NewClient = func(logLabels ...map[string]string) helm.HelmClient {
+	helm.NewClient = func(logLabels ...map[string]string) client.HelmClient {
 		return &helm.MockHelmClient{}
 	}
 	mm := NewMainModuleManager()
@@ -1173,7 +1174,7 @@ func Test_MainModuleManager_DiscoverModulesState(t *testing.T) {
 			modulesState = nil
 			err = nil
 
-			helm.NewClient = func(logLabels ...map[string]string) helm.HelmClient {
+			helm.NewClient = func(logLabels ...map[string]string) client.HelmClient {
 				return &helm.MockHelmClient{
 					ReleaseNames: test.helmReleases,
 				}


### PR DESCRIPTION
- if helm 3 is in path, use it to manage module charts
- --helm-history-max and --helm-timeout flags for upgrade operation
- fix namespace in module resource-monitor output
- reduce helm history executions