### PR TITLE
fix: inconsistent label cardinality

### DIFF
--- a/pkg/module_manager/module.go
+++ b/pkg/module_manager/module.go
@@ -505,6 +505,7 @@ func (m *Module) runHooksByBindingAndCheckValues(binding BindingType, logLabels 
 			"module":     m.Name,
 			"hook":       moduleHook.Name,
 			"binding":    string(binding),
+			"queue":      "main", // AfterHelm,BeforeHelm hooks always handle in main queue
 			"activation": logLabels["event.type"],
 		}
 


### PR DESCRIPTION
```
Metric histogram observe deckhouse_module_hook_run_seconds [activation binding hook module] with map[activation: binding:afterHelm hook:hook-name module:module-name]: inconsistent label cardinality: expected 5 label values but got 4 in prometheus.Labels{\"activation\":\"\",
\"binding\":\"afterHelm\", \"hook\":\"hook-name\", \"module\":\"module-name\"}"
```