### PR TITLE
Fix detect helm version

### DIFF
--- a/pkg/helm/helm3/helm3.go
+++ b/pkg/helm/helm3/helm3.go
@@ -94,12 +94,18 @@ func (h *Helm3Client) Cmd(args ...string) (stdout string, stderr string, err err
 
 // InitAndVersion runs helm version command.
 func (h *Helm3Client) InitAndVersion() error {
-	stdout, stderr, err := h.Cmd("version", "--short")
+	stdout, stderr, err := h.Cmd("version", "--template='{{ .Client.SemVer }}'")
 	if err != nil {
 		return fmt.Errorf("unable to get helm version: %v\n%v %v", err, stdout, stderr)
 	}
+
 	stdout = strings.Join([]string{stdout, stderr}, "\n")
 	stdout = strings.ReplaceAll(stdout, "\n", " ")
+
+	if stdout[2:3] == "2" {
+		return fmt.Errorf("detected Helm2 client version")
+	}
+
 	log.Infof("Helm 3 version: %s", stdout)
 
 	return nil


### PR DESCRIPTION
To fix bug with detect Helm3 version [(isssue)](https://github.com/flant/addon-operator/issues/144) this PR change function **InitAndVersion** in helm3.go.
If function recognize that version of Helm is 2 than function is return error ""detected Helm2 client version"", after that the addon operator is correctly initialized.