### PR TITLE
fix: detection of helm version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,8 @@ jobs:
   build_binary:
     name: Build addon-operator binary
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Set up Go 1.12
         uses: actions/setup-go@v1

--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -40,6 +40,8 @@ jobs:
             }
 
   build_dev_image:
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     name: Dev image
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,8 @@ jobs:
   run_linter:
     name: Run linter
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Set up Go 1.12
         uses: actions/setup-go@v1

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -20,6 +20,8 @@ jobs:
           - alpine3.10
           - alpine3.11
     runs-on: [ubuntu-latest]
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,8 @@ jobs:
     name: Run unit tests
     if: github.event_name == 'push' && github.event.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Set up Go 1.12
         uses: actions/setup-go@v1
@@ -132,6 +134,8 @@ jobs:
     name: Download modules and build libjq
     if: (github.event_name == 'push' && github.event.ref == 'refs/heads/master') || (github.event_name == 'pull_request' && github.event.label.id == 1860105491) # push to master or set ':robot: full tests' label
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Set up Go 1.12
         uses: actions/setup-go@v1
@@ -214,6 +218,8 @@ jobs:
     if: (github.event_name == 'push' && github.event.ref == 'refs/heads/master') || (github.event_name == 'pull_request' && github.event.label.id == 1860105491) # push to master or set ':robot: full tests' label
     needs: prepare_build_dependencies
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v1

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -69,7 +69,7 @@ dev_cluster_live_ticks 32
 **ADDON_OPERATOR_TILLER_LISTEN_PORT** — a port used for communication with helm (-listen flag). Default is 44435.
 **ADDON_OPERATOR_TILLER_PROBE_LISTEN_PORT** — a port used for Tiller probes (-probe-listen flag). Default is 44434.
 
-Tiller starts as a subprocess and listens on 127.0.01 address. Defaults are good, but if Addon-operator should start with `hostNetwork: true`, then these variables will come in handy.
+Tiller starts as a subprocess and listens on 127.0.0.1 address. Defaults are good, but if Addon-operator should start with `hostNetwork: true`, then these variables will come in handy.
 
 ### Kubernetes client settings
 
@@ -78,6 +78,18 @@ Tiller starts as a subprocess and listens on 127.0.01 address. Defaults are good
 **KUBE_CONTEXT** — a context name in a kubernetes client config (similar to a `--context` flag of a kubectl)
 
 **KUBE_CLIENT_QPS** and **KUBE_CLIENT_BURST** — qps and burst parameters to rate-limit requests to Kubernetes API server. Default qps is 5 and burst is 10 as in a [rest/config.go](https://github.com/kubernetes/client-go/blob/v0.17.0/rest/config.go#L44) file.
+
+### Helm settings
+
+Addon-operator expects that "helm" binary is available in $PATH. It detects Helm version at start by executing "helm --help" command. If this is not appropriate by some reasons, you can use these settings:
+
+**HELM_BIN_PATH** — a path to a Helm binary.
+
+**TILLER_BIN_PATH** — a path to a Tiller binary.
+
+**HELM2** — set to "yes" to disable auto-detection and explicitly enable compatibility with helm2.
+
+**HELM3** — set to "yes" to disable auto-detection and explicitly enable compatibility with helm3.
 
 ### Logging settings
 

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/flant/shell-operator v1.0.0-beta.10.0.20200708094531-126d47838bc0/go.
 github.com/flant/shell-operator v1.0.0-beta.11 h1:16OSOtaNcryrrhIB4fnBOit5qFFuDVNTvefhf7sonvQ=
 github.com/flant/shell-operator v1.0.0-beta.11.0.20200814110804-eb5e60516b10 h1:NDo9A9E3i+hX3oLvhm3BMyA/FbYOWSDmK63E9geEbV0=
 github.com/flant/shell-operator v1.0.0-beta.11.0.20200814110804-eb5e60516b10/go.mod h1:+a3IijbQpjr8zBudwk4Y4GkS1Hx+xUjaKr9Mx/H6Nsw=
+github.com/flant/shell-operator v1.0.0-beta.12.0.20200903102652-4e8b8ad0bb3e h1:kjPh6PcytSkq5eDnvA9ZOcSlaS+G/4Le8dQOXk1I+3Y=
 github.com/flant/shell-operator v1.0.0-beta.12.0.20200903102652-4e8b8ad0bb3e/go.mod h1:+a3IijbQpjr8zBudwk4Y4GkS1Hx+xUjaKr9Mx/H6Nsw=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -18,41 +18,48 @@ var NewClient = func(logLabels ...map[string]string) client.HelmClient {
 var HealthzHandler func(writer http.ResponseWriter, request *http.Request)
 
 func Init(client kube.KubernetesClient) error {
-	// Try helm3 first
-	err := helm3.Init(&helm3.Helm3Options{
-		Namespace:  app.Namespace,
-		HistoryMax: app.Helm3HistoryMax,
-		Timeout:    app.Helm3Timeout,
-		KubeClient: client,
-	})
-	if err == nil {
+	helmVersion, err := DetectHelmVersion()
+	if err != nil {
+		return err
+	}
+
+	if helmVersion == "v3" {
+		// Use helm3 client.
 		NewClient = helm3.NewClient
-		return nil
+		err = helm3.Init(&helm3.Helm3Options{
+			Namespace:  app.Namespace,
+			HistoryMax: app.Helm3HistoryMax,
+			Timeout:    app.Helm3Timeout,
+			KubeClient: client,
+		})
+		return err
 	}
 
-	// Fallback to helm2
-	// TODO make tiller cancelable
-	err = helm2.InitTillerProcess(helm2.TillerOptions{
-		Namespace:          app.Namespace,
-		HistoryMax:         app.TillerMaxHistory,
-		ListenAddress:      app.TillerListenAddress,
-		ListenPort:         app.TillerListenPort,
-		ProbeListenAddress: app.TillerProbeListenAddress,
-		ProbeListenPort:    app.TillerProbeListenPort,
-	})
-	if err != nil {
-		return fmt.Errorf("init tiller: %s", err)
+	if helmVersion == "v2" {
+		// TODO make tiller cancelable
+		err = helm2.InitTillerProcess(helm2.TillerOptions{
+			Namespace:          app.Namespace,
+			HistoryMax:         app.TillerMaxHistory,
+			ListenAddress:      app.TillerListenAddress,
+			ListenPort:         app.TillerListenPort,
+			ProbeListenAddress: app.TillerProbeListenAddress,
+			ProbeListenPort:    app.TillerProbeListenPort,
+		})
+		if err != nil {
+			return fmt.Errorf("init tiller: %s", err)
+		}
+
+		// Initialize helm2 client
+		err = helm2.Init(&helm2.Helm2Options{
+			Namespace:  app.Namespace,
+			KubeClient: client,
+		})
+		if err != nil {
+			return fmt.Errorf("init helm client: %s", err)
+		}
+		NewClient = helm2.NewClient
+		HealthzHandler = helm2.TillerHealthHandler()
 	}
 
-	// Initialize helm2 client
-	err = helm2.Init(&helm2.Helm2Options{
-		Namespace:  app.Namespace,
-		KubeClient: client,
-	})
-	if err != nil {
-		return fmt.Errorf("init helm client: %s", err)
-	}
-	NewClient = helm2.NewClient
-	HealthzHandler = helm2.TillerHealthHandler()
 	return nil
 }

--- a/pkg/helm/helm2/helm2.go
+++ b/pkg/helm/helm2/helm2.go
@@ -20,7 +20,7 @@ import (
 	"github.com/flant/shell-operator/pkg/kube"
 )
 
-const Helm2Path = "helm"
+var Helm2Path = "helm"
 
 type Helm2Options struct {
 	Namespace  string

--- a/pkg/helm/helm2/tiller.go
+++ b/pkg/helm/helm2/tiller.go
@@ -16,7 +16,8 @@ import (
 	"github.com/flant/shell-operator/pkg/utils/labels"
 )
 
-const TillerPath = "tiller"
+var TillerPath = "tiller"
+
 const TillerWaitTimeoutSeconds = 2
 const TillerWaitRetryDelay = 250 * time.Millisecond
 const TillerWaitTimeout = 10 * time.Second // Should not be less than TillerWaitTimeoutSeconds + TillerWaitRetryDelay

--- a/pkg/helm/helm3/helm3.go
+++ b/pkg/helm/helm3/helm3.go
@@ -20,7 +20,7 @@ import (
 	"github.com/flant/shell-operator/pkg/kube"
 )
 
-const Helm3Path = "helm"
+var Helm3Path = "helm"
 
 type Helm3Options struct {
 	Namespace  string

--- a/pkg/helm/version_detect.go
+++ b/pkg/helm/version_detect.go
@@ -1,0 +1,51 @@
+package helm
+
+import (
+	"fmt"
+	"github.com/flant/addon-operator/pkg/helm/helm2"
+	"github.com/flant/addon-operator/pkg/helm/helm3"
+	"os"
+	"os/exec"
+	"regexp"
+)
+
+const DefaultHelmBinPath = "helm"
+
+func DetectHelmVersion() (string, error) {
+	// Setup default universal helm path
+	helmPath := os.Getenv("HELM_BIN_PATH")
+	if helmPath == "" {
+		helmPath = DefaultHelmBinPath
+	}
+	helm2.Helm2Path = helmPath
+	helm3.Helm3Path = helmPath
+
+	tillerPath := os.Getenv("TILLER_BIN_PATH")
+	if tillerPath != "" {
+		helm2.TillerPath = tillerPath
+	}
+
+	if os.Getenv("HELM3") == "yes" {
+		return "v3", nil
+	}
+
+	if os.Getenv("HELM2") == "yes" {
+		return "v2", nil
+	}
+
+	// No environments, try to autodetect via execution `helm --help` command.
+	// Helm3 has no mentions of "tiller" in help output.
+	cmd := exec.Command(helmPath, "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("execute helm --help: %v\n%s", err, string(out))
+	}
+	tillerRe := regexp.MustCompile(`tiller`)
+	tillerLoc := tillerRe.FindIndex(out)
+	if tillerLoc != nil {
+		return "v2", nil
+	}
+
+	// TODO helm4 detection?
+	return "v3", nil
+}

--- a/pkg/helm/version_detect_test.go
+++ b/pkg/helm/version_detect_test.go
@@ -1,0 +1,41 @@
+package helm
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// Test requires helm and helm2 binaries in $PATH.
+func Test_DetectHelmVersion(t *testing.T) {
+	t.SkipNow()
+
+	g := NewWithT(t)
+
+	os.Setenv("HELM2", "yes")
+
+	ver, err := DetectHelmVersion()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(ver).Should(Equal("v2"))
+
+	os.Setenv("HELM2", "")
+	os.Setenv("HELM3", "yes")
+
+	ver, err = DetectHelmVersion()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(ver).Should(Equal("v3"))
+
+	// Test autodetection
+	os.Setenv("HELM2", "")
+	os.Setenv("HELM3", "")
+
+	ver, err = DetectHelmVersion()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(ver).Should(Equal("v3"))
+
+	os.Setenv("HELM_BIN_PATH", "helm2")
+	ver, err = DetectHelmVersion()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(ver).Should(Equal("v2"))
+}


### PR DESCRIPTION
Use "helm --help" to detect helm 2. Add environment variables to override helm and tiller paths and to set helm version compatibility.