### PR TITLE
fix: fix typo of helm3 Render comment

### DIFF
--- a/pkg/helm/helm3/helm3.go
+++ b/pkg/helm/helm3/helm3.go
@@ -292,7 +292,7 @@ func (h *Helm3Client) ListReleasesNames(labelSelector map[string]string) ([]stri
 	return uniqNames, nil
 }
 
-// ListReleasesNames returns list of release names without suffixes ".v<release_number>"
+// Render renders helm templates for chart
 func (h *Helm3Client) Render(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) (string, error) {
 	args := make([]string, 0)
 	args = append(args, "template")


### PR DESCRIPTION
fix code comment typo for `helm3` func `Render`

PTAL

/cc @diafour 