### PR TITLE
fix: cleanup helm values after upgrading a module

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -1829,6 +1829,7 @@ func (op *AddonOperator) SetupDebugServerHandles() {
 			_, _ = writer.Write([]byte(err.Error()))
 			return
 		}
+		defer os.Remove(valuesPath)
 
 		helmCl := helm.NewClient()
 		output, err := helmCl.Render(m.Name, m.Path, []string{valuesPath}, nil, app.Namespace)

--- a/pkg/module_manager/module.go
+++ b/pkg/module_manager/module.go
@@ -276,6 +276,7 @@ func (m *Module) runHelmInstall(logLabels map[string]string) error {
 	if err != nil {
 		return err
 	}
+	defer os.Remove(valuesPath)
 
 	helmClient := helm.NewClient(logLabels)
 


### PR DESCRIPTION
#### Overview
Remove `values.yaml` files from a tmp dir after installing a module.

#### What this PR does / why we need it
Addon-operator accumulates values files making the tmp folder to burst.
It makes difference when you trigger module reinstallation frequently.
```
root@kube-master / # du -sh /tmp/addon-operator/
140M	/tmp/addon-operator/
root@kube-master /# ls /tmp/addon-operator/ | grep values | wc -l
5979
```

#### Does this PR introduce a user-facing change?
It's more about internal mechanics.

```release-note
cleanup helm values after upgrading a module 
```