### PR TITLE
fix: add ApplyDefaults for module values

### DIFF
--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -1020,8 +1020,9 @@ func (mm *moduleManager) GlobalStaticAndConfigValues() utils.Values {
 	return MergeLayers(
 		utils.Values{"global": map[string]interface{}{}},
 		mm.commonStaticValues.Global(),
-		mm.kubeGlobalConfigValues,
+		// Apply config values defaults before ConfigMap overrides.
 		&ApplyDefaultsForGlobal{validation.ConfigValuesSchema},
+		mm.kubeGlobalConfigValues,
 	)
 }
 
@@ -1031,8 +1032,9 @@ func (mm *moduleManager) GlobalStaticAndNewValues(newValues utils.Values) utils.
 	return MergeLayers(
 		utils.Values{"global": map[string]interface{}{}},
 		mm.commonStaticValues.Global(),
-		newValues,
+		// Apply config values defaults before overrides.
 		&ApplyDefaultsForGlobal{validation.ConfigValuesSchema},
+		newValues,
 	)
 }
 
@@ -1043,9 +1045,10 @@ func (mm *moduleManager) GlobalValues() (utils.Values, error) {
 	res := MergeLayers(
 		utils.Values{"global": map[string]interface{}{}},
 		mm.commonStaticValues.Global(),
+		// Apply config values defaults before ConfigMap overrides.
 		&ApplyDefaultsForGlobal{validation.ConfigValuesSchema},
 		mm.kubeGlobalConfigValues,
-		// Apply defaults before patches.
+		// Apply dynamic values defaults before patches.
 		&ApplyDefaultsForGlobal{validation.MemoryValuesSchema},
 	)
 


### PR DESCRIPTION

#### Overview

Add AplyDefaults to module values

#### What this PR does / why we need it

Defaults from openapi schemas were applied only to global values.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

No

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```