### PR TITLE
feat: execution rate settings for hooks

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -38,12 +38,11 @@ During execution, a module hook receives global values and module values. Module
 
 ### onStartup
 
-Example JSON syntax:
+Example:
 
-```json
-{
-  "onStartup": ORDER
-}
+```yaml
+configVersion: v1
+onStartup: ORDER
 ```
 
 Parameters:
@@ -52,12 +51,11 @@ Parameters:
 
 ### beforeAll
 
-Example JSON syntax:
+Example:
 
-```json
-{
-  "beforeAll": ORDER
-}
+```yaml
+configVersion: v1
+beforeAll: ORDER
 ```
 
 Parameters:
@@ -66,12 +64,11 @@ Parameters:
 
 ### afterAll
 
-Example JSON syntax:
+Example:
 
-```json
-{
-  "afterAll": ORDER
-}
+```yaml
+configVersion: v1
+afterAll: ORDER
 ```
 
 Parameters:
@@ -80,12 +77,11 @@ Parameters:
 
 ### beforeHelm
 
-Example JSON syntax:
+Example:
 
-```json
-{
-  "beforeHelm": ORDER
-}
+```yaml
+configVersion: v1
+beforeHelm: ORDER
 ```
 
 Parameters:
@@ -94,12 +90,11 @@ Parameters:
 
 ### afterHelm
 
-Example JSON syntax:
+Example:
 
-```json
-{
-  "afterHelm": ORDER
-}
+```yaml
+configVersion: v1
+afterHelm: ORDER
 ```
 
 Parameters:
@@ -108,12 +103,11 @@ Parameters:
 
 ### afterDeleteHelm
 
-Example JSON syntax:
+Example:
 
-```json
-{
-  "afterDeleteHelm": ORDER
-}
+```yaml
+configVersion: v1
+afterDeleteHelm: ORDER
 ```
 
 Parameters:
@@ -165,15 +159,17 @@ kubernetes:
 
 This hook will be executed *before* updating the Helm release with this binding context:
 
-```json
-[{"binding":"beforeAll",
-"snapshots":{
-  "monitor-pods":[
+```yaml
+[{"binding": "beforeAll",
+"snapshots": {
+  "monitor-pods": [
     {
-      "object":{
-        "kind":"Pod,
+      "object": {
+        "kind": "Pod",
         "apiVersion": "v1",
-        "metadata":{ "name":"pod-1r62e3", "namespace":"default", ...},
+        "metadata": {
+          "name":"pod-1r62e3",
+          "namespace":"default", ...},
         ...
       },
       "filterResult": {
@@ -188,3 +184,7 @@ This hook will be executed *before* updating the Helm release with this binding 
 }
 }]
 ```
+
+### Execution rate
+
+Hook configuration has a `settings` section with parameters `executionMinPeriod` and `executionBurst`. These parameters are used to throttle hook executions and wait for more events in the queue. See section [execution rate](https://github.com/flant/shell-operator/blob/master/HOOKS.md#execution-rate) from the Shell-operator.

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -91,6 +91,14 @@ Addon-operator expects that "helm" binary is available in $PATH. It detects Helm
 
 **HELM3** — set to "yes" to disable auto-detection and explicitly enable compatibility with helm3.
 
+**HELM_IGNORE_RELEASE** — a name of the release that should not be treated as the module's release. Prevent self-destruction when addon-operator release is stored in the same namespace as releases for modules.
+
+```
+env:
+- name: HELM_IGNORE_RELEASE
+  value: {{ .Release.Name }}
+```
+
 ### Logging settings
 
 **LOG_TYPE** — Logging formatter type: `json`, `text` or `color`.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.9.0+incompatible
-	github.com/flant/shell-operator v1.0.0-rc.2 // tag: v1.0.0-rc.2
+	github.com/flant/shell-operator v1.0.0-rc.2.0.20210309122030-e12b710ba118 // branch: master
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/spec v0.19.3
 	github.com/go-openapi/strfmt v0.19.3

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,13 @@ github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a h1:PlStPekqPtTSWD
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/shell-operator v1.0.0-rc.2 h1:a7qjZiq6cPz8icx7vVoa44HV+5Zno5LPX/8FT+PqsiM=
 github.com/flant/shell-operator v1.0.0-rc.2/go.mod h1:pq8wYfmaG5UT5MocnNZUzVMFw/n93kay+pYNyHOj+C0=
+github.com/flant/shell-operator v1.0.0-rc.2.0.20210301093335-489eb49059db h1:fHjzdMOOyVKhtNVLHB7iy/2V4xdG1wySHyJTrcTx/eE=
+github.com/flant/shell-operator v1.0.0-rc.2.0.20210301093335-489eb49059db/go.mod h1:SYvDlbFLsn128jWnVU3nqW1iqCRTn+QCzjjJgkWfllM=
+github.com/flant/shell-operator v1.0.0-rc.2.0.20210302075139-437ffd66fadd h1:NW1AHaQAIakEekiV6HSxQu0wyS/ceSSjg7Tk1216vTY=
+github.com/flant/shell-operator v1.0.0-rc.2.0.20210302075139-437ffd66fadd/go.mod h1:SYvDlbFLsn128jWnVU3nqW1iqCRTn+QCzjjJgkWfllM=
+github.com/flant/shell-operator v1.0.0-rc.2.0.20210304192910-4b9d0df35834 h1:zBg/TNuV95MhU3kpeqOgdQ3zZebN8hc69jcHLT6F2eI=
+github.com/flant/shell-operator v1.0.0-rc.2.0.20210304192910-4b9d0df35834/go.mod h1:SYvDlbFLsn128jWnVU3nqW1iqCRTn+QCzjjJgkWfllM=
+github.com/flant/shell-operator v1.0.0-rc.2.0.20210309122030-e12b710ba118/go.mod h1:SYvDlbFLsn128jWnVU3nqW1iqCRTn+QCzjjJgkWfllM=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -25,6 +25,7 @@ var TillerMaxHistory int32 = 0
 
 var Helm3HistoryMax int32 = 10
 var Helm3Timeout time.Duration = 5 * time.Minute
+var HelmIgnoreRelease = ""
 
 var Namespace = ""
 var ConfigMapName = "addon-operator"
@@ -88,6 +89,10 @@ func DefineStartCommandFlags(kpApp *kingpin.Application, cmd *kingpin.CmdClause)
 		Envar("HELM_TIMEOUT").
 		Default(Helm3Timeout.String()).
 		DurationVar(&Helm3Timeout)
+
+	cmd.Flag("helm-ignore-release", "Helm3+: do not count release as a module release.").
+		Envar("HELM_IGNORE_RELEASE").
+		StringVar(&HelmIgnoreRelease)
 
 	cmd.Flag("config-map", "Name of a ConfigMap to store values.").
 		Envar("ADDON_OPERATOR_CONFIG_MAP").

--- a/pkg/helm/helm3/helm3.go
+++ b/pkg/helm/helm3/helm3.go
@@ -14,6 +14,7 @@ import (
 	kblabels "k8s.io/apimachinery/pkg/labels"
 	k8syaml "sigs.k8s.io/yaml"
 
+	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/utils"
 	"github.com/flant/shell-operator/pkg/executor"
@@ -282,6 +283,9 @@ func (h *Helm3Client) ListReleasesNames(labelSelector map[string]string) ([]stri
 			uniqNamesMap[releaseName] = struct{}{}
 		}
 	}
+
+	// Do not return ignored release.
+	delete(uniqNamesMap, app.HelmIgnoreRelease)
 
 	uniqNames := make([]string, 0)
 	for name := range uniqNamesMap {

--- a/pkg/module_manager/global_hook.go
+++ b/pkg/module_manager/global_hook.go
@@ -9,11 +9,11 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/satori/go.uuid.v1"
 
+	"github.com/flant/shell-operator/pkg/hook"
 	. "github.com/flant/shell-operator/pkg/hook/binding_context"
 	. "github.com/flant/shell-operator/pkg/hook/types"
 
 	. "github.com/flant/addon-operator/pkg/hook/types"
-
 	"github.com/flant/addon-operator/pkg/utils"
 	"github.com/flant/addon-operator/sdk"
 )
@@ -44,6 +44,8 @@ func (g *GlobalHook) WithConfig(configOutput []byte) (err error) {
 	}
 	// Make HookController and GetConfigDescription work.
 	g.Hook.Config = &g.Config.HookConfig
+	g.Hook.RateLimiter = hook.CreateRateLimiter(g.Hook.Config)
+
 	return nil
 }
 

--- a/pkg/module_manager/module_hook.go
+++ b/pkg/module_manager/module_hook.go
@@ -9,10 +9,11 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/satori/go.uuid.v1"
 
-	. "github.com/flant/addon-operator/pkg/hook/types"
+	"github.com/flant/shell-operator/pkg/hook"
 	. "github.com/flant/shell-operator/pkg/hook/binding_context"
 	. "github.com/flant/shell-operator/pkg/hook/types"
 
+	. "github.com/flant/addon-operator/pkg/hook/types"
 	"github.com/flant/addon-operator/pkg/utils"
 	"github.com/flant/addon-operator/sdk"
 )
@@ -48,6 +49,8 @@ func (m *ModuleHook) WithConfig(configOutput []byte) (err error) {
 	}
 	// Make HookController and GetConfigDescription work.
 	m.Hook.Config = &m.Config.HookConfig
+	m.Hook.RateLimiter = hook.CreateRateLimiter(m.Hook.Config)
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Bring in execution rate settings from shell-operator: https://github.com/flant/shell-operator/pull/257.

Add `HELM_IGNORE_RELEASE` option to not treat the addon-operator release as a module.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

1. Addon-operator can combine tasks in the queue and run the hook once with an array of binding contexts. Execution rate settings help to handle multiple events that are occurred during a short period.

2. `HELM_IGNORE_RELEASE` prevents self-destcruction in setup where addon-operator release is stored in the same namespace as modules (`ADDON_OPERATOR_NAMESPACE`).

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```