### PR TITLE
feat: use separate kube client for helm resources monitor

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -99,6 +99,10 @@ env:
   value: {{ .Release.Name }}
 ```
 
+**HELM_MONITOR_KUBE_CLIENT_QPS** — QPS for a rate limiter of a kubernetes client for Helm resources monitor.
+
+**HELM_MONITOR_KUBE_CLIENT_BURST** — Burst for a rate limiter of a kubernetes client for Helm resources monitor.
+
 ### Logging settings
 
 **LOG_TYPE** — Logging formatter type: `json`, `text` or `color`.

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -26,6 +26,10 @@ var TillerMaxHistory int32 = 0
 var Helm3HistoryMax int32 = 10
 var Helm3Timeout time.Duration = 5 * time.Minute
 var HelmIgnoreRelease = ""
+var HelmMonitorKubeClientQpsDefault = "5" // DefaultQPS from k8s.io/client-go/rest/config.go
+var HelmMonitorKubeClientQps float32
+var HelmMonitorKubeClientBurstDefault = "10" // DefaultBurst from k8s.io/client-go/rest/config.go
+var HelmMonitorKubeClientBurst int
 
 var Namespace = ""
 var ConfigMapName = "addon-operator"
@@ -93,6 +97,16 @@ func DefineStartCommandFlags(kpApp *kingpin.Application, cmd *kingpin.CmdClause)
 	cmd.Flag("helm-ignore-release", "Helm3+: do not count release as a module release.").
 		Envar("HELM_IGNORE_RELEASE").
 		StringVar(&HelmIgnoreRelease)
+
+	// Rate limit settings for kube client used by Helm resources monitor.
+	cmd.Flag("helm-monitor-kube-client-qps", "QPS for a rate limiter of a kubernetes client for Helm resources monitor. Can be set with $HELM_MONITOR_KUBE_CLIENT_QPS.").
+		Envar("HELM_MONITOR_KUBE_CLIENT_QPS").
+		Default(HelmMonitorKubeClientQpsDefault).
+		Float32Var(&HelmMonitorKubeClientQps)
+	cmd.Flag("helm-monitor-kube-client-burst", "Burst for a rate limiter of a kubernetes client for Helm resources monitor. Can be set with $HELM_MONITOR_KUBE_CLIENT_BURST.").
+		Envar("HELM_MONITOR_KUBE_CLIENT_BURST").
+		Default(HelmMonitorKubeClientBurstDefault).
+		IntVar(&HelmMonitorKubeClientBurst)
 
 	cmd.Flag("config-map", "Name of a ConfigMap to store values.").
 		Envar("ADDON_OPERATOR_CONFIG_MAP").


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Add a separate kube client for Helm resources monitor.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

The addon-operator uses the same kube client for hook events and for Helm resources monitor. Helm resources monitor periodically lists all resources defined in Helm charts and kube client becomes rate limited. This PR adds new flags to set separate rate limit settings for Helm resources monitor.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```