### PR TITLE
fix: ignore 'nonexistent path' errors from 'remove' patch operations

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
@@ -169,6 +170,7 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -257,6 +259,7 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
+github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterbourgon/mergemap v0.0.0-20130613134717-e21c03b7a721 h1:ArxMo6jAOO2KuRsepZ0hTaH4hZCi2CCW4P9PV59HHH0=
 github.com/peterbourgon/mergemap v0.0.0-20130613134717-e21c03b7a721/go.mod h1:jQyRpOpE/KbvPc0VKXjAqctYglwUO5W6zAcGcFfbvlo=

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ github.com/flant/shell-operator v1.0.0-rc.2.0.20210312082814-474da3366f0c h1:Lhv
 github.com/flant/shell-operator v1.0.0-rc.2.0.20210312082814-474da3366f0c/go.mod h1:RHkdgTcyRh/B3imV4O13xH7rmDazd6V5RZ8E3hVq8BM=
 github.com/flant/shell-operator v1.0.0-rc.2.0.20210317131220-020ac6f87d1b h1:cCE0eSoYLTSMDLU37M9JpmU9THomBqsHP+mKIf+e1LM=
 github.com/flant/shell-operator v1.0.0-rc.2.0.20210317131220-020ac6f87d1b/go.mod h1:RHkdgTcyRh/B3imV4O13xH7rmDazd6V5RZ8E3hVq8BM=
+github.com/flant/shell-operator v1.0.0-rc.2.0.20210318171436-f4a0b109c0e3 h1:NXBT14/gedxiEgHQJL5vfYxVgNBv9b8NaPu8IKC+Fnc=
 github.com/flant/shell-operator v1.0.0-rc.2.0.20210318171436-f4a0b109c0e3/go.mod h1:k1dYfFRa/HGq8f6ApXhsWLAVjuWo7cQrNQU+UdjnC10=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/module_manager/global_hook.go
+++ b/pkg/module_manager/global_hook.go
@@ -106,7 +106,8 @@ func (h *GlobalHook) handleGlobalValuesPatch(currentValues utils.Values, valuesP
 		return nil, nil
 	}
 
-	newValues, valuesChanged, err := utils.ApplyValuesPatch(currentValues, globalValuesPatch)
+	// Apply new patches in Strict mode. Hook should not return 'remove' with nonexistent path.
+	newValues, valuesChanged, err := utils.ApplyValuesPatch(currentValues, globalValuesPatch, utils.Strict)
 	if err != nil {
 		return nil, fmt.Errorf("merge global values failed: %s", err)
 	}

--- a/pkg/module_manager/module.go
+++ b/pkg/module_manager/module.go
@@ -766,7 +766,7 @@ func (m *Module) Values() (utils.Values, error) {
 	for _, patch := range m.moduleManager.modulesDynamicValuesPatches[m.Name] {
 		// Invariant: do not store patches that does not apply
 		// Give user error for patches early, after patch receive
-		res, _, err = utils.ApplyValuesPatch(res, patch)
+		res, _, err = utils.ApplyValuesPatch(res, patch, utils.IgnoreNonExistentPaths)
 		if err != nil {
 			return nil, fmt.Errorf("construct module values: apply module patch error: %s", err)
 		}

--- a/pkg/module_manager/module_hook.go
+++ b/pkg/module_manager/module_hook.go
@@ -108,7 +108,8 @@ func (h *ModuleHook) handleModuleValuesPatch(currentValues utils.Values, valuesP
 		return nil, fmt.Errorf("merge module '%s' values failed: %s", h.Module.Name, err)
 	}
 
-	newValues, valuesChanged, err := utils.ApplyValuesPatch(currentValues, valuesPatch)
+	// Apply new patches in Strict mode. Hook should not return 'remove' with nonexistent path.
+	newValues, valuesChanged, err := utils.ApplyValuesPatch(currentValues, valuesPatch, utils.Strict)
 	if err != nil {
 		return nil, fmt.Errorf("merge module '%s' values failed: %s", h.Module.Name, err)
 	}

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -1077,7 +1077,7 @@ func (mm *moduleManager) GlobalValues() (utils.Values, error) {
 	// Invariant: do not store patches that does not apply
 	// Give user error for patches early, after patch receive
 	for _, patch := range mm.globalDynamicValuesPatches {
-		res, _, err = utils.ApplyValuesPatch(res, patch)
+		res, _, err = utils.ApplyValuesPatch(res, patch, utils.IgnoreNonExistentPaths)
 		if err != nil {
 			return nil, fmt.Errorf("apply global patch error: %s", err)
 		}

--- a/pkg/utils/values_patch_test.go
+++ b/pkg/utils/values_patch_test.go
@@ -455,7 +455,7 @@ func Test_CompactPatches_Apply(t *testing.T) {
 
 			assert.True(t, jsonpatch.Equal(origPatchedDoc, []byte(tt.expected)), "%s should be equal to %s", origPatchedDoc, tt.expected)
 
-			newPatch := CompactPatches(operations)
+			newPatch := CompactPatches(nil, operations)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Ignore errors from 'remove' patch operations.

#### What this PR does / why we need it

It is a common situation when config values contain a key, then hook returns a patch and removes this key. Lately, user edits a ConfigMap and also removes a key. Since then, the patch set is "poisoned" with the 'remove' operation of a nonexistent key.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```