### PR TITLE
fix: change forum link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 Community forum
-    url: https://community.flant.com/c/shell-operator/7
+  - name: 💬 Github Discussions
+    url: https://github.com/flant/addon-operator/discussions
     about: Please ask and answer questions here

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,6 +1,6 @@
 ---
 name: 🚀 Feature request
-about: Suggest an idea for Shell-operator
+about: Suggest an idea for Addon-operator
 ---
 <!--
   Thank you for sending a feature request!


### PR DESCRIPTION

#### Overview
Ask questions on the Github Discussions instead of Flant community site

#### What this PR does / why we need it
We decided to switch to `discussions` because it already has all the necessary features

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note

```