### PR TITLE
fix: go hook config converter

### DIFF
--- a/pkg/module_manager/global_hook_config.go
+++ b/pkg/module_manager/global_hook_config.go
@@ -301,8 +301,9 @@ func NewHookConfigFromGoConfig(input *go_hook.HookConfig) (config.HookConfig, er
 		if kubeCfg.Filterable == nil {
 			return config.HookConfig{}, errors.New(`"Filterable" in KubernetesConfig cannot be nil`)
 		}
-		monitor.FilterFunc = func(unstructured *unstructured.Unstructured) (interface{}, error) {
-			return kubeCfg.Filterable.ApplyFilter(unstructured)
+		filterable := kubeCfg.Filterable
+		monitor.FilterFunc = func(obj *unstructured.Unstructured) (interface{}, error) {
+			return filterable.ApplyFilter(obj)
 		}
 		if go_hook.BoolDeref(kubeCfg.ExecuteHookOnEvents, true) {
 			monitor.WithEventTypes(nil)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Only last Filterable is used:

```
Kubernetes: []go_hook.KubernetesConfig{
		{
			Name:                         "pods",
			ApiVersion:                   "v1",
			Kind:                         "Pod",
			Filterable:                   &Fitlerable1{},
		},
		{
			Name:                         "secrets",
			ApiVersion:                   "v1",
			Kind:                         "Secret",
			Filterable:                   &SecretObject{},
		},
	},
```


```
1 *hooks.SecretObject *hooks.SecretObject
2 *hooks.SecretObject *hooks.SecretObject *hooks.SecretObject
```

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```