### PR TITLE
Replaced Filterable with FilterFunc, also, some changes in the registry.go

### DIFF
--- a/pkg/module_manager/global_hook_config.go
+++ b/pkg/module_manager/global_hook_config.go
@@ -298,12 +298,12 @@ func NewHookConfigFromGoConfig(input *go_hook.HookConfig) (config.HookConfig, er
 		monitor.WithFieldSelector(kubeCfg.FieldSelector)
 		monitor.WithNamespaceSelector(kubeCfg.NamespaceSelector)
 		monitor.WithLabelSelector(kubeCfg.LabelSelector)
-		if kubeCfg.Filterable == nil {
-			return config.HookConfig{}, errors.New(`"Filterable" in KubernetesConfig cannot be nil`)
+		if kubeCfg.FilterFunc == nil {
+			return config.HookConfig{}, errors.New(`"FilterFunc" in KubernetesConfig cannot be nil`)
 		}
-		filterable := kubeCfg.Filterable
+		filterFunc := kubeCfg.FilterFunc
 		monitor.FilterFunc = func(obj *unstructured.Unstructured) (interface{}, error) {
-			return filterable.ApplyFilter(obj)
+			return filterFunc(obj)
 		}
 		if go_hook.BoolDeref(kubeCfg.ExecuteHookOnEvents, true) {
 			monitor.WithEventTypes(nil)

--- a/pkg/module_manager/go_hook/go_hook.go
+++ b/pkg/module_manager/go_hook/go_hook.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type GoHook interface {
@@ -66,15 +65,7 @@ type ScheduleConfig struct {
 	Crontab string
 }
 
-type Filterable interface {
-	ApplyFilter(*unstructured.Unstructured) (FilterResult, error)
-}
-
-func ConvertUnstructured(obj *unstructured.Unstructured, target interface{}) error {
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), target)
-
-	return err
-}
+type FilterFunc func(*unstructured.Unstructured) (FilterResult, error)
 
 type KubernetesConfig struct {
 	Name                         string
@@ -87,7 +78,7 @@ type KubernetesConfig struct {
 	ExecuteHookOnEvents          *bool
 	ExecuteHookOnSynchronization *bool
 	WaitForSynchronization       *bool
-	Filterable                   Filterable
+	FilterFunc                   FilterFunc
 }
 
 type OrderedConfig struct {

--- a/pkg/module_manager/test/go_hooks/global-hooks/simple.go
+++ b/pkg/module_manager/test/go_hooks/global-hooks/simple.go
@@ -6,18 +6,11 @@ import (
 	"github.com/flant/shell-operator/pkg/metric_storage/operation"
 )
 
-var _ = sdk.Register(&Simple{})
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnAfterAll: &go_hook.OrderedConfig{Order: 5},
+}, run)
 
-type Simple struct {
-}
-
-func (s *Simple) Config() *go_hook.HookConfig {
-	return &go_hook.HookConfig{
-		OnAfterAll: &go_hook.OrderedConfig{Order: 5},
-	}
-}
-
-func (s *Simple) Run(input *go_hook.HookInput) error {
+func run(input *go_hook.HookInput) error {
 	input.Values.Set("test", "test")
 	*input.Metrics = append(*input.Metrics, operation.MetricOperation{Name: "test"})
 

--- a/sdk/registry.go
+++ b/sdk/registry.go
@@ -22,19 +22,8 @@ var moduleRe = regexp.MustCompile(`/modules/(([^/]+)/hooks/([^/]+/)*([^/]+))$`)
 // TODO: This regexp should be changed. We shouldn't force users to name modules with a number prefix.
 var moduleNameRe = regexp.MustCompile(`^[0-9][0-9][0-9]-(.*)$`)
 
-var _ = initRegistry()
-
-func initRegistry() bool {
-	Register = func(h go_hook.GoHook) bool {
-		Registry().Add(h)
-		return true
-	}
-
-	RegisterFunc = func(config *go_hook.HookConfig, reconcileFunc reconcileFunc) bool {
-		Registry().Add(newCommonGoHook(config, reconcileFunc))
-		return true
-	}
-
+var RegisterFunc = func(config *go_hook.HookConfig, reconcileFunc reconcileFunc) bool {
+	Registry().Add(newCommonGoHook(config, reconcileFunc))
 	return true
 }
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -2,13 +2,9 @@ package sdk
 
 import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
-
-// Register is a method to define go hooks.
-// return value is for trick with
-//   var _ =
-var Register = func(_ go_hook.GoHook) bool { return false }
-var RegisterFunc = func(config *go_hook.HookConfig, reconcileFunc reconcileFunc) bool { return false }
 
 var _ go_hook.GoHook = (*commonGoHook)(nil)
 
@@ -29,4 +25,13 @@ func (h *commonGoHook) Config() *go_hook.HookConfig {
 
 func (h *commonGoHook) Run(input *go_hook.HookInput) error {
 	return h.reconcileFunc(input)
+}
+
+func ToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	return &unstructured.Unstructured{Object: content}, err
+}
+
+func FromUnstructured(unstructuredObj *unstructured.Unstructured, obj runtime.Object) error {
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj)
 }


### PR DESCRIPTION
#### Overview

1. Replaced Filterable with FilterFunc
2. Removed Register(), left only RegisterFunc()
3. Added helper function to convert to and from Unstructured objects

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

The Filterable interface is unwieldy and impossible to reason about. Replaced it with a simple function.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```