### PR TITLE
fix: Name and Path in go hook metadata

### DIFF
--- a/pkg/module_manager/hook.go
+++ b/pkg/module_manager/hook.go
@@ -272,7 +272,10 @@ func (mm *moduleManager) RegisterGlobalHooks() error {
 	if err != nil {
 		return err
 	}
-	log.Debugf("Found %d global hooks", len(hooks))
+	log.Debugf("Found %d global hooks:", len(hooks))
+	for _, h := range hooks {
+		log.Debugf("  GlobalHook: Name=%s, Path=%s", h.Name, h.Path)
+	}
 
 	for _, globalHook := range hooks {
 		logEntry := log.WithField("hook", globalHook.Name).
@@ -378,6 +381,9 @@ func (mm *moduleManager) RegisterModuleHooks(module *Module, logLabels map[strin
 		return err
 	}
 	logEntry.Debugf("Found %d hooks", len(hooks))
+	for _, h := range hooks {
+		logEntry.Debugf("  ModuleHook: Name=%s, Path=%s", h.Name, h.Path)
+	}
 
 	for _, moduleHook := range hooks {
 		hookLogEntry := logEntry.WithField("hook", moduleHook.Name).

--- a/pkg/module_manager/hook_executor_test.go
+++ b/pkg/module_manager/hook_executor_test.go
@@ -17,10 +17,13 @@ func Test_Config_GoHook(t *testing.T) {
 
 	moduleManager := NewMainModuleManager()
 
+	expectedGoHookName := "simple.go"
+	expectedGoHookPath := "/global-hooks/simple.go"
+
 	var goHook go_hook.GoHook
-	gh := NewGlobalHook("simple.go", "simple.go")
+	gh := NewGlobalHook(expectedGoHookName, expectedGoHookPath)
 	for _, hookWithMeta := range sdk.Registry().Hooks() {
-		if hookWithMeta.Metadata.Name == "simple.go" && hookWithMeta.Metadata.Path == "simple.go" {
+		if hookWithMeta.Metadata.Name == expectedGoHookName && hookWithMeta.Metadata.Path == expectedGoHookPath {
 			goHook = hookWithMeta.Hook
 			break
 		}

--- a/pkg/module_manager/module_manager_test.go
+++ b/pkg/module_manager/module_manager_test.go
@@ -557,13 +557,6 @@ func Test_MainModuleManager_Get_ModuleHooksInOrder(t *testing.T) {
 				}
 
 				assert.Equal(t, expectedOrder, moduleHooks)
-
-				for mod := range mm.allModulesByName {
-					for _, modHookName := range mm.GetModuleHookNames(mod) {
-						h := mm.GetModuleHook(modHookName)
-						fmt.Printf("module '%s' hook '%s': hook.Name: '%s', hook.Path:'%s'\n", mod, modHookName, h.Name, h.Path)
-					}
-				}
 			},
 		},
 		{

--- a/pkg/module_manager/module_manager_test.go
+++ b/pkg/module_manager/module_manager_test.go
@@ -557,6 +557,13 @@ func Test_MainModuleManager_Get_ModuleHooksInOrder(t *testing.T) {
 				}
 
 				assert.Equal(t, expectedOrder, moduleHooks)
+
+				for mod := range mm.allModulesByName {
+					for _, modHookName := range mm.GetModuleHookNames(mod) {
+						h := mm.GetModuleHook(modHookName)
+						fmt.Printf("module '%s' hook '%s': hook.Name: '%s', hook.Path:'%s'\n", mod, modHookName, h.Name, h.Path)
+					}
+				}
 			},
 		},
 		{

--- a/sdk/registry.go
+++ b/sdk/registry.go
@@ -9,15 +9,15 @@ import (
 )
 
 // /path/.../global-hooks/a/b/c/Hook-name.go
-// $1 - Hook path
-// $3 - Hook name
-var globalRe = regexp.MustCompile(`/global[\/\-]hooks/(([^/]+/)*([^/]+))$`)
+// $1 - Hook path for sorting (/global/hooks/subdir/v1-hook-onstartup.go)
+// $2 - Hook name for identification (subdir/v1-hook-onstartup.go)
+var globalRe = regexp.MustCompile(`(/global[\/\-]hooks/(([^/]+/)*([^/]+)))$`)
 
 // /path/.../modules/module-name/hooks/a/b/c/Hook-name.go
-// $1 - Hook path
-// $2 - module name
-// $4 - Hook name
-var moduleRe = regexp.MustCompile(`/modules/(([^/]+)/hooks/([^/]+/)*([^/]+))$`)
+// $1 - Hook path for sorting (/modules/002-helm-and-hooks/hooks/subdir/some_hook)
+// $2 - Hook name for identification (002-helm-and-hooks/hooks/subdir/some_hook)
+// $3 - Path element with module name (002-helm-and-hooks)
+var moduleRe = regexp.MustCompile(`(/modules/(([^/]+)/hooks/([^/]+/)*([^/]+)))$`)
 
 // TODO: This regexp should be changed. We shouldn't force users to name modules with a number prefix.
 var moduleNameRe = regexp.MustCompile(`^[0-9][0-9][0-9]-(.*)$`)
@@ -70,7 +70,7 @@ func (h *HookRegistry) Add(hook go_hook.GoHook) {
 		matches := globalRe.FindStringSubmatch(frame.File)
 		if matches != nil {
 			hookMeta.Global = true
-			hookMeta.Name = matches[3]
+			hookMeta.Name = matches[2]
 			hookMeta.Path = matches[1]
 			break
 		}
@@ -78,9 +78,9 @@ func (h *HookRegistry) Add(hook go_hook.GoHook) {
 		matches = moduleRe.FindStringSubmatch(frame.File)
 		if matches != nil {
 			hookMeta.Module = true
-			hookMeta.Name = matches[4]
+			hookMeta.Name = matches[2]
 			hookMeta.Path = matches[1]
-			modNameMatches := moduleNameRe.FindStringSubmatch(matches[2])
+			modNameMatches := moduleNameRe.FindStringSubmatch(matches[3])
 			if modNameMatches != nil {
 				hookMeta.ModuleName = modNameMatches[1]
 			}

--- a/sdk/test/sdk_test.go
+++ b/sdk/test/sdk_test.go
@@ -32,19 +32,19 @@ func Test_HookMetadata_from_runtime(t *testing.T) {
 	g.Expect(ok).To(BeTrue(), "global go-hook.go should be registered")
 	g.Expect(hm.Global).To(BeTrue())
 	g.Expect(hm.Module).To(BeFalse())
-	g.Expect(hm.Path).To(Equal("go-hook.go"))
+	g.Expect(hm.Path).To(Equal("/global-hooks/go-hook.go"))
 
-	hm, ok = hooks["module-one-hook.go"]
+	hm, ok = hooks["001-module-one/hooks/module-one-hook.go"]
 	g.Expect(ok).To(BeTrue(), "module-one-hook.go should be registered")
 	g.Expect(hm.Global).To(BeFalse())
 	g.Expect(hm.Module).To(BeTrue())
 	g.Expect(hm.ModuleName).To(Equal("module-one"))
-	g.Expect(hm.Path).To(Equal("001-module-one/hooks/module-one-hook.go"))
+	g.Expect(hm.Path).To(Equal("/modules/001-module-one/hooks/module-one-hook.go"))
 
-	hm, ok = hooks["sub-sub-hook.go"]
+	hm, ok = hooks["002-module-two/hooks/level1/sublevel/sub-sub-hook.go"]
 	g.Expect(ok).To(BeTrue(), "sub-sub-hook.go should be registered")
 	g.Expect(hm.Global).To(BeFalse())
 	g.Expect(hm.Module).To(BeTrue())
 	g.Expect(hm.ModuleName).To(Equal("module-two"))
-	g.Expect(hm.Path).To(Equal("002-module-two/hooks/level1/sublevel/sub-sub-hook.go"))
+	g.Expect(hm.Path).To(Equal("/modules/002-module-two/hooks/level1/sublevel/sub-sub-hook.go"))
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Fix Name and Path fields for go hooks to be in line with shell hooks.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Each hook is registered with "Name" and "Path". "Name" is used as a hook identifier in shell-operator managers and "Path" is used for sorting binding with the same order (for completeness Path is also used to run shell hooks). Shell-operator managers are simple and know nothing about modules/global hooks. So we end up running the wrong hook if there are go hooks with the same file name but in different modules. This fix makes Name and Path for go hooks similar to shell hooks.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```