### PR TITLE
fix: FromUnstructured not work for custom struct without DeepCopy implementation

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -27,11 +27,11 @@ func (h *commonGoHook) Run(input *go_hook.HookInput) error {
 	return h.reconcileFunc(input)
 }
 
-func ToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+func ToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	return &unstructured.Unstructured{Object: content}, err
 }
 
-func FromUnstructured(unstructuredObj *unstructured.Unstructured, obj runtime.Object) error {
+func FromUnstructured(unstructuredObj *unstructured.Unstructured, obj interface{}) error {
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj)
 }


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Change type of the `obj` parameter to `interface{}`

#### What this PR does / why we need it

Custom Resource struct may not implement runtime.Object and DefaultUnstructuredConverter not requires runtime.Object.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```