### PR TITLE
Add flag to start scheduling 'schedule' hook before first converge done.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/flant/kube-client v0.0.6
-	github.com/flant/shell-operator v1.0.8
+	github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/spec v0.19.8
 	github.com/go-openapi/strfmt v0.19.5

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a h1:PlStPekqPtTSWD
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/shell-operator v1.0.8 h1:yPrjByvRHxveXfKuxD0yf07jOPD/Wv4c0YnaC15r7EE=
 github.com/flant/shell-operator v1.0.8/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
+github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da h1:DPVDviZzDUWP3OSXB2I/Ttxu1K4fosxmDA3uHMTgcr8=
+github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -223,7 +223,7 @@ func (op *AddonOperator) NeedAddCrontabTask(hook *module_manager.CommonHook) boo
 
 	s := hook.GoHook.Config().Settings
 
-	if s != nil && s.EnableSchedulesOnStartup == true {
+	if s != nil && s.EnableSchedulesOnStartup {
 		return true
 	}
 

--- a/pkg/module_manager/go_hook/go_hook.go
+++ b/pkg/module_manager/go_hook/go_hook.go
@@ -162,6 +162,9 @@ type HookConfig struct {
 type HookConfigSettings struct {
 	ExecutionMinInterval time.Duration
 	ExecutionBurst       int
+	// EnableSchedulesOnStartup
+	// set to true, if you need to run 'Schedule' hooks without waiting addon-operator readiness
+	EnableSchedulesOnStartup bool
 }
 
 type ScheduleConfig struct {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Revert starting schedule manager on start operator instead starting after first converge.

For go-hooks added flag `HookConfigSettings.EnableSchedulesOnStartup` for enable schedule hook without waiting finish converge.

By default all hooks (go and shell) will be running after converge. 

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Some schedule hooks can run critical routines for operator (for ex, [deckhouse](https://github.com/deckhouse/deckhouse) uses them for auto-updating itself.)

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
Users can use schedule go-hooks before first converge.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```