### PR TITLE
fix: beforeHelm hook got empty snapshots for some bindings

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -187,7 +187,7 @@ This hook will be executed *before* updating the Helm release with this binding 
 
 ### Synchronization for global hooks
 
-[Synchronization](https://github.com/flant/shell-operator/blob/main/HOOKS.md#synchronization-binding-context) is a first run of global hooks with "kubernetes" bindings. As with the shell-operator, it occurs right after the success of the global "onStartup" hooks, but the following behaviour is slightly different. By default, the addon-operator waits for hooks with `executeHookOnSynchronization: true` to finish before proceeding to "beforeAll" hooks. You can skip this waiting for bindings in parallel queues by setting `waitForSynchronization: false`.
+[Synchronization](https://github.com/flant/shell-operator/blob/main/HOOKS.md#synchronization-binding-context) is the first run of global hooks with "kubernetes" bindings. As with the Shell-operator, it executes right after the successful completion of global "onStartup" hooks, but the following behavior is slightly different. By default, the Addon-operator executes "beforeAll" hooks after the completion of hooks with `executeHookOnSynchronization: true`. Set `waitForSynchronization: false` to execute these hooks in parallel with "beforeAll" hooks.
 
 For example, a global hook with `kubernetes` and `beforeAll` bindings may have this configuration:
 
@@ -203,19 +203,19 @@ kubernetes:
   apiVersion: v1
   kind: Node
   jqFilter: ".metadata.labels"
-  queue: config-map-handling-queue
+  queue: nodes-handling
   executeHookOnSynchronization: false
 - name: monitor-cms
   apiVersion: v1
   kind: ConfigMap
   jqFilter: ".metadata.labels"
-  queue: config-map-handling-queue
+  queue: config-map-handling
   waitForSynchronization: false
 - name: monitor-secrets
   apiVersion: v1
   kind: Secret
   jqFilter: ".metadata.labels"
-  queue: secrets-handling-queue
+  queue: secrets-handling
   executeHookOnSynchronization: false
   waitForSynchronization: false
 ```
@@ -224,13 +224,16 @@ This hook will be executed after "onStartup" as follows:
 
 - Run hook with binding context for the "monitor-pods" binding in the "main" queue.
 - Fill snapshot for the "monitor-nodes" binding, do not execute hook.
-- Run in parallel: 1) hook with the "beforeAll" binding context in the "main" queue, 2) hook with the "monitor-cms" binding context in the "config-map-handling-queue" queue, and 3) fill snapshot for the "monitor-secrets" binding.
+- Run in parallel:
+  - hook with the "beforeAll" binding context in the "main" queue
+  - hook with the "monitor-cms" binding context in the "config-map-handling" queue
+  - fill snapshot for the "monitor-secrets" binding.
 
 > Note: there is no guarantee that the "beforeAll" binding context contains snapshots with ConfigMaps and Secrets.
 
 ### Synchronization for module hooks
 
-[Synchronization](https://github.com/flant/shell-operator/blob/main/HOOKS.md#synchronization-binding-context) is a first run of module hooks with "kubernetes" bindings after module enablement. It occurs right after the success of the module's "onStartup" hooks. By default, the addon-operator waits for hooks with `executeHookOnSynchronization: true` to finish before proceeding to "beforeHelm" hooks. You can skip this waiting for bindings in parallel queues by setting `waitForSynchronization: false`.
+[Synchronization](https://github.com/flant/shell-operator/blob/main/HOOKS.md#synchronization-binding-context) is the first run of module hooks with "kubernetes" bindings after module enablement. It executes right after the successful completion of the module's "onStartup" hooks. By default, the Addon-operator executes "beforeHelm" hooks after the completion of hooks with `executeHookOnSynchronization: true`. Set `waitForSynchronization: false` to execute these hooks in parallel with "beforeHelm" hooks.
 
 For example, a module hook with `kubernetes` and `beforeHelm` bindings may have this configuration:
 
@@ -246,19 +249,19 @@ kubernetes:
   apiVersion: v1
   kind: Node
   jqFilter: ".metadata.labels"
-  queue: config-map-handling-queue
+  queue: nodes-handling
   executeHookOnSynchronization: false
 - name: monitor-cms
   apiVersion: v1
   kind: ConfigMap
   jqFilter: ".metadata.labels"
-  queue: config-map-handling-queue
+  queue: config-map-handling
   waitForSynchronization: false
 - name: monitor-secrets
   apiVersion: v1
   kind: Secret
   jqFilter: ".metadata.labels"
-  queue: secrets-handling-queue
+  queue: secrets-handling
   executeHookOnSynchronization: false
   waitForSynchronization: false
 ```
@@ -267,7 +270,10 @@ This hook will be executed after "onStartup" as follows:
 
 - Run hook with binding context for the "monitor-pods" binding in the "main" queue.
 - Fill snapshot for the "monitor-nodes" binding, do not execute hook.
-- Run in parallel: 1) hook with the "beforeHelm" binding context in the "main" queue, 2) hook with the "monitor-cms" binding context in the "config-map-handling-queue" queue, and 3) fill snapshot for the "monitor-secrets" binding.
+- Run in parallel: 
+  - hook with the "beforeHelm" binding context in the "main" queue
+  - hook with the "monitor-cms" binding context in the "config-map-handling" queue
+  - fill snapshot for the "monitor-secrets" binding
 
 > Note: there is no guarantee that the "beforeHelm" binding context contains snapshots with ConfigMaps and Secrets.
 

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,6 @@ github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2a
 github.com/flant/kube-client v0.0.6/go.mod h1:pVKIewJQ5oaBiE6AlTaWAUkd0548DEiyvkqkLaby3Zg=
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a h1:PlStPekqPtTSWDDKFlwgETsT1OiXD1gZtRHcNxAs1lc=
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
-github.com/flant/shell-operator v1.0.8 h1:yPrjByvRHxveXfKuxD0yf07jOPD/Wv4c0YnaC15r7EE=
-github.com/flant/shell-operator v1.0.8/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
 github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da h1:DPVDviZzDUWP3OSXB2I/Ttxu1K4fosxmDA3uHMTgcr8=
 github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=

--- a/pkg/module_manager/global_hook.go
+++ b/pkg/module_manager/global_hook.go
@@ -28,10 +28,8 @@ var _ Hook = &GlobalHook{}
 
 func NewGlobalHook(name, path string) *GlobalHook {
 	res := &GlobalHook{
-		CommonHook: &CommonHook{
-			KubernetesBindingSynchronizationState: make(map[string]*KubernetesBindingSynchronizationState),
-		},
-		Config: &GlobalHookConfig{},
+		CommonHook: &CommonHook{},
+		Config:     &GlobalHookConfig{},
 	}
 	res.Name = name
 	res.Path = path

--- a/pkg/module_manager/go_hook/go_hook.go
+++ b/pkg/module_manager/go_hook/go_hook.go
@@ -168,24 +168,36 @@ type HookConfigSettings struct {
 }
 
 type ScheduleConfig struct {
-	Name    string
+	Name string
+	// Crontab is a schedule config in crontab format. (5 or 6 fields)
 	Crontab string
 }
 
 type FilterFunc func(*unstructured.Unstructured) (FilterResult, error)
 
 type KubernetesConfig struct {
-	Name                         string
-	ApiVersion                   string
-	Kind                         string
-	NameSelector                 *types.NameSelector
-	NamespaceSelector            *types.NamespaceSelector
-	LabelSelector                *v1.LabelSelector
-	FieldSelector                *types.FieldSelector
-	ExecuteHookOnEvents          *bool
+	// Name is a key in snapshots map.
+	Name string
+	// ApiVersion of objects. "v1" is used if not set.
+	ApiVersion string
+	// Kind of objects.
+	Kind string
+	// NameSelector used to subscribe on object by its name.
+	NameSelector *types.NameSelector
+	// NamespaceSelector used to subscribe on objects in namespaces.
+	NamespaceSelector *types.NamespaceSelector
+	// LabelSelector used to subscribe on objects by matching their labels.
+	LabelSelector *v1.LabelSelector
+	// FieldSelector used to subscribe on objects by matching specific fields (the list of fields is narrow, see shell-operator documentation).
+	FieldSelector *types.FieldSelector
+	// ExecuteHookOnEvents is true by default. Set to false if only snapshot update is needed.
+	ExecuteHookOnEvents *bool
+	// ExecuteHookOnSynchronization is true by default. Set to false if only snapshot update is needed.
 	ExecuteHookOnSynchronization *bool
-	WaitForSynchronization       *bool
-	FilterFunc                   FilterFunc
+	// WaitForSynchronization is true by default. Set to false if beforeHelm is not required this snapshot on start.
+	WaitForSynchronization *bool
+	// FilterFunc used to filter object content for snapshot. Addon-operator use checksum of this filtered result to ignore irrelevant events.
+	FilterFunc FilterFunc
 }
 
 type OrderedConfig struct {
@@ -193,8 +205,11 @@ type OrderedConfig struct {
 }
 
 type HookBindingContext struct {
-	Type      string // type: Event Synchronization Group Schedule
-	Binding   string // binding name
+	// Type of binding context: [Event, Synchronization, Group, Schedule]
+	Type string
+	// Binding is a related binding name.
+	Binding string
+	// Snapshots contain all objects for all bindings.
 	Snapshots map[string][]types.ObjectAndFilterResult
 }
 

--- a/pkg/module_manager/hook.go
+++ b/pkg/module_manager/hook.go
@@ -31,11 +31,6 @@ type Hook interface {
 	Order(binding sh_op_types.BindingType) float64
 }
 
-type KubernetesBindingSynchronizationState struct {
-	Queued bool
-	Done   bool
-}
-
 func (k *KubernetesBindingSynchronizationState) String() string {
 	return fmt.Sprintf("queue=%v done=%v", k.Queued, k.Done)
 }
@@ -44,8 +39,6 @@ type CommonHook struct {
 	hook.Hook
 
 	moduleManager *moduleManager
-
-	KubernetesBindingSynchronizationState map[string]*KubernetesBindingSynchronizationState
 
 	GoHook go_hook.GoHook
 }
@@ -78,28 +71,6 @@ func (h *CommonHook) SynchronizationNeeded() bool {
 		}
 	}
 	return false
-}
-
-// SynchronizationQueued is true if at least one KubernetesBindingSynchronizationState object has true for Queued.
-func (h *CommonHook) SynchronizationQueued() bool {
-	queued := false
-	for _, state := range h.KubernetesBindingSynchronizationState {
-		if state.Queued {
-			queued = true
-		}
-	}
-	return queued
-}
-
-// SynchronizationDone is true if all KubernetesBindingSynchronizationState objects has true for Done.
-func (h *CommonHook) SynchronizationDone() bool {
-	done := true
-	for _, state := range h.KubernetesBindingSynchronizationState {
-		if !state.Done {
-			done = false
-		}
-	}
-	return done
 }
 
 // SearchGlobalHooks recursively find all executables in hooksDir. Absent hooksDir is not an error.

--- a/pkg/module_manager/module_hook.go
+++ b/pkg/module_manager/module_hook.go
@@ -29,10 +29,8 @@ var _ Hook = &ModuleHook{}
 
 func NewModuleHook(name, path string) *ModuleHook {
 	res := &ModuleHook{
-		CommonHook: &CommonHook{
-			KubernetesBindingSynchronizationState: make(map[string]*KubernetesBindingSynchronizationState),
-		},
-		Config: &ModuleHookConfig{},
+		CommonHook: &CommonHook{},
+		Config:     &ModuleHookConfig{},
 	}
 	res.Name = name
 	res.Path = path

--- a/pkg/module_manager/module_manager_test.go
+++ b/pkg/module_manager/module_manager_test.go
@@ -313,7 +313,7 @@ func Test_MainModuleManager_Get_Module(t *testing.T) {
 						ModuleEnabledKey: "moduleEnabled",
 						RawConfig:        []string{},
 					},
-					State:         &ModuleState{},
+					State:         NewModuleState(),
 					moduleManager: mm,
 				}
 				assert.Equal(t, expectedModule, module)

--- a/pkg/module_manager/module_state.go
+++ b/pkg/module_manager/module_state.go
@@ -1,0 +1,35 @@
+package module_manager
+
+type ModuleRunPhase string
+
+const (
+	// Startup - module is just enabled.
+	Startup ModuleRunPhase = "Startup"
+	// OnStartupDone - onStartup hooks are done.
+	OnStartupDone ModuleRunPhase = "OnStartupDone"
+	// QueueSynchronizationTasks - should queue Synchronization tasks.
+	QueueSynchronizationTasks ModuleRunPhase = "QueueSynchronizationTasks"
+	// WaitForSynchronization - some Synchronization tasks are in queues, should wait for them to finish.
+	WaitForSynchronization ModuleRunPhase = "WaitForSynchronization"
+	// EnableScheduleBindings - enable schedule binding after Synchronization.
+	EnableScheduleBindings ModuleRunPhase = "EnableScheduleBindings"
+	// CanRunHelm - module is ready to run its Helm chart.
+	CanRunHelm ModuleRunPhase = "CanRunHelm"
+)
+
+type ModuleState struct {
+	Enabled              bool
+	Phase                ModuleRunPhase
+	synchronizationState *SynchronizationState
+}
+
+func NewModuleState() *ModuleState {
+	return &ModuleState{
+		Phase:                Startup,
+		synchronizationState: NewSynchronizationState(),
+	}
+}
+
+func (s *ModuleState) Synchronization() *SynchronizationState {
+	return s.synchronizationState
+}

--- a/pkg/module_manager/synchronization_state.go
+++ b/pkg/module_manager/synchronization_state.go
@@ -1,0 +1,89 @@
+package module_manager
+
+import (
+	log "github.com/sirupsen/logrus"
+	"sync"
+
+	"github.com/flant/addon-operator/pkg/task"
+)
+
+// KubernetesBindingSynchronizationState is a state of the single Synchronization task.
+type KubernetesBindingSynchronizationState struct {
+	HookName    string
+	BindingName string
+	Queued      bool
+	Done        bool
+}
+
+// SynchronizationState can be used to track synchronization tasks for global or for module.
+type SynchronizationState struct {
+	state map[string]*KubernetesBindingSynchronizationState
+	m     sync.RWMutex
+}
+
+func NewSynchronizationState() *SynchronizationState {
+	return &SynchronizationState{
+		state: make(map[string]*KubernetesBindingSynchronizationState),
+	}
+}
+
+func (s *SynchronizationState) HasQueued() bool {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	queued := false
+	for _, state := range s.state {
+		if state.Queued {
+			queued = true
+			break
+		}
+	}
+	return queued
+}
+
+// IsComplete returns true if all states are in done status.
+func (s *SynchronizationState) IsComplete() bool {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	done := true
+	for _, state := range s.state {
+		if !state.Done {
+			done = false
+		}
+	}
+	return done
+}
+
+func (s *SynchronizationState) QueuedForBinding(metadata task.HookMetadata) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	var state *KubernetesBindingSynchronizationState
+	state, ok := s.state[metadata.KubernetesBindingId]
+	if !ok {
+		state = &KubernetesBindingSynchronizationState{
+			HookName:    metadata.HookName,
+			BindingName: metadata.Binding,
+		}
+		s.state[metadata.KubernetesBindingId] = state
+	}
+	state.Queued = true
+}
+
+func (s *SynchronizationState) DoneForBinding(id string) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	var state *KubernetesBindingSynchronizationState
+	state, ok := s.state[id]
+	if !ok {
+		state = &KubernetesBindingSynchronizationState{}
+		s.state[id] = state
+	}
+	state.Done = true
+}
+
+func (s *SynchronizationState) DebugDumpState(logEntry *log.Entry) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	for id, state := range s.state {
+		logEntry.Debugf("%s/%s: queued=%v done=%v id=%s", state.HookName, state.BindingName, state.Queued, state.Done, id)
+	}
+}


### PR DESCRIPTION

#### Overview


- Queue Synchronization tasks for all hooks to properly enable monitors and events.
- Replace multiple module state flags with one phase.
- Move Synchronization state from hooks into module.
- Extract Synchronization state to the struct.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Now beforeHelm hook always got snapshots from all kubernetes binding beside executeHookOnSynchronization/waitForSynchronization settings.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```