### PR TITLE
chore: remove unused ValuesChecksumsAnnotation

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -168,7 +168,6 @@ func (op *AddonOperator) InitModuleManager() error {
 	op.KubeConfigManager.WithContext(op.ctx)
 	op.KubeConfigManager.WithNamespace(app.Namespace)
 	op.KubeConfigManager.WithConfigMapName(app.ConfigMapName)
-	op.KubeConfigManager.WithValuesChecksumsAnnotation(app.ValuesChecksumsAnnotation)
 
 	err = op.KubeConfigManager.Init()
 	if err != nil {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -33,7 +33,6 @@ var HelmMonitorKubeClientBurst int
 
 var Namespace = ""
 var ConfigMapName = "addon-operator"
-var ValuesChecksumsAnnotation = "addon-operator/values-checksums"
 
 var GlobalHooksDir = "global-hooks"
 var ModulesDir = "modules"

--- a/pkg/kube_config_manager/kube_config_manager.go
+++ b/pkg/kube_config_manager/kube_config_manager.go
@@ -23,7 +23,6 @@ type KubeConfigManager interface {
 	WithKubeClient(client klient.Client)
 	WithNamespace(namespace string)
 	WithConfigMapName(configMap string)
-	WithValuesChecksumsAnnotation(annotation string)
 	SetKubeGlobalValues(values utils.Values) error
 	SetKubeModuleValues(moduleName string, values utils.Values) error
 	Init() error
@@ -177,10 +176,6 @@ func (kcm *kubeConfigManager) WithNamespace(namespace string) {
 
 func (kcm *kubeConfigManager) WithConfigMapName(configMap string) {
 	kcm.ConfigMapName = configMap
-}
-
-// No need in annotation anymore.
-func (kcm *kubeConfigManager) WithValuesChecksumsAnnotation(_ string) {
 }
 
 func (kcm *kubeConfigManager) SetKubeGlobalValues(values utils.Values) error {

--- a/pkg/kube_config_manager/kube_config_manager_test.go
+++ b/pkg/kube_config_manager/kube_config_manager_test.go
@@ -269,9 +269,6 @@ func TestKubeConfigManager_ModuleConfigsUpdated_chan(t *testing.T) {
 	cm := &v1.ConfigMap{}
 	cm.SetNamespace("default")
 	cm.SetName(app.ConfigMapName)
-	//cm.SetAnnotations(map[string]string{
-	//	app.ValuesChecksumsAnnotation: `{"module1":"asdasdzxczxcqweqwe"}`,
-	//})
 	cm.Data = map[string]string{
 		"global": `
 param1: val1
@@ -287,7 +284,6 @@ param2: val2
 	kcm.WithKubeClient(kubeClient)
 	kcm.WithNamespace("default")
 	kcm.WithConfigMapName(app.ConfigMapName)
-	//	kcm.WithValuesChecksumsAnnotation(app.ValuesChecksumsAnnotation)
 
 	err = kcm.Init()
 	g.Expect(err).ShouldNot(HaveOccurred(), "KubeConfigManager should init correctly")
@@ -327,9 +323,6 @@ func TestKubeConfigManager_SetKubeModuleValues(t *testing.T) {
 	cm := &v1.ConfigMap{}
 	cm.SetNamespace("default")
 	cm.SetName(app.ConfigMapName)
-	//cm.SetAnnotations(map[string]string{
-	//	app.ValuesChecksumsAnnotation: `{"module1":"asdasdzxczxcqweqwe"}`,
-	//})
 	cm.Data = map[string]string{
 		"global": `
 param1: val1
@@ -345,7 +338,6 @@ param2: val2
 	kcm.WithKubeClient(kubeClient)
 	kcm.WithNamespace("default")
 	kcm.WithConfigMapName(app.ConfigMapName)
-	//kcm.WithValuesChecksumsAnnotation(app.ValuesChecksumsAnnotation)
 
 	err = kcm.Init()
 	g.Expect(err).ShouldNot(HaveOccurred(), "KubeConfigManager should init correctly")
@@ -372,11 +364,4 @@ moduleLongName:
 	g.Expect(cm.Data).Should(HaveLen(2))
 	g.Expect(cm.Data).To(HaveKey("global"))
 	g.Expect(cm.Data).To(HaveKey("moduleLongName"))
-
-	//g.Expect(cm.Annotations).To(HaveKey(app.ValuesChecksumsAnnotation))
-	//// chacksum annotation should contain an initial key 'module1' and a new key 'module-long-name'
-	//anno := cm.Annotations[app.ValuesChecksumsAnnotation]
-	//
-	//g.Expect(anno).To(ContainSubstring("module-long-name"))
-	//g.Expect(anno).To(ContainSubstring("module1"))
 }

--- a/pkg/module_manager/module_manager_test.go
+++ b/pkg/module_manager/module_manager_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm"
 	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/kube_config_manager"
@@ -70,7 +69,6 @@ func initModuleManager(t *testing.T, mm *moduleManager, configPath string) {
 		KubeConfigManager.WithContext(context.Background())
 		KubeConfigManager.WithNamespace("default")
 		KubeConfigManager.WithConfigMapName("addon-operator")
-		KubeConfigManager.WithValuesChecksumsAnnotation(app.ValuesChecksumsAnnotation)
 
 		err = KubeConfigManager.Init()
 		if err != nil {


### PR DESCRIPTION
#### Overview

ValuesChecksumsAnnotation was used to store config values
cheksums in the annotation on the ConfigMap/addon-operator.
Later this mechanism is proved to be error-prone. Now it is
replaced with checksums fields in KubeConfigManager (#154).



<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Clean up code left after ValuesChecksumsAnnotation deletion.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```