### PR TITLE
Disable OpenAPI validation for manifests rendering in helm3lib

### DIFF
--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -326,7 +326,18 @@ func (h *LibClient) ListReleasesNames(labelSelector map[string]string) ([]string
 }
 
 // Render renders helm templates for chart
-func (h *LibClient) Render(releaseName string, chartName string, valuesPaths []string, setValues []string, namespace string) (string, error) {
+func (h *LibClient) Render(releaseName, chartName string, valuesPaths, setValues []string, namespace string) (string, error) {
+	manifest, err := h.render(releaseName, chartName, valuesPaths, setValues, namespace)
+	if err != nil {
+		// same as install. we can have some feature gate here for validation and we have to reload kube client
+		h.reinitKubeClient()
+		return h.render(releaseName, chartName, valuesPaths, setValues, namespace)
+	}
+
+	return manifest, nil
+}
+
+func (h *LibClient) render(releaseName, chartName string, valuesPaths, setValues []string, namespace string) (string, error) {
 	chart, err := loader.Load(chartName)
 	if err != nil {
 		return "", err

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -325,19 +325,7 @@ func (h *LibClient) ListReleasesNames(labelSelector map[string]string) ([]string
 	return uniqNames, nil
 }
 
-// Render renders helm templates for chart
 func (h *LibClient) Render(releaseName, chartName string, valuesPaths, setValues []string, namespace string) (string, error) {
-	manifest, err := h.render(releaseName, chartName, valuesPaths, setValues, namespace)
-	if err != nil {
-		// same as install. we can have some feature gate here for validation and we have to reload kube client
-		h.reinitKubeClient()
-		return h.render(releaseName, chartName, valuesPaths, setValues, namespace)
-	}
-
-	return manifest, nil
-}
-
-func (h *LibClient) render(releaseName, chartName string, valuesPaths, setValues []string, namespace string) (string, error) {
 	chart, err := loader.Load(chartName)
 	if err != nil {
 		return "", err
@@ -377,6 +365,7 @@ func (h *LibClient) render(releaseName, chartName string, valuesPaths, setValues
 	inst.UseReleaseName = true
 	inst.Replace = true // Skip the name check
 	inst.IsUpgrade = true
+	inst.DisableOpenAPIValidation = true
 
 	rs, err := inst.Run(chart, resultValues)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Disable OpenAPI validation on manifest rendering

#### What this PR does / why we need it

We need it to avoid some cases like FeatureGates changing during the operator lifetime. Install/Upgrade command also checks validation though this method (Render) can securely disable validation cause of only manifests checksum building

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?


```release-note
NONE
```