### PR TITLE
fix: runtimeConfig dependency, log level for snapshot info

### DIFF
--- a/cmd/addon-operator/main.go
+++ b/cmd/addon-operator/main.go
@@ -46,6 +46,7 @@ func main() {
 			log.Infof("%s %s, shell-operator %s", app.AppName, app.Version, sh_app.Version)
 
 			operator := addon_operator.DefaultOperator()
+			operator.WithRuntimeConfig(runtimeConfig)
 			err := addon_operator.InitAndStart(operator)
 			if err != nil {
 				os.Exit(1)

--- a/pkg/module_manager/global_hook.go
+++ b/pkg/module_manager/global_hook.go
@@ -152,7 +152,7 @@ func (h *GlobalHook) Run(bindingType BindingType, bindingContext []BindingContex
 
 	for _, info := range h.HookController.SnapshotsInfo() {
 		log.WithFields(utils.LabelsToLogFields(logLabels)).
-			Infof("snapshot info: %s", info)
+			Debugf("snapshot info: %s", info)
 	}
 
 	globalHookExecutor := NewHookExecutor(h, bindingContext, h.Config.Version, h.moduleManager.KubeObjectPatcher)

--- a/pkg/module_manager/module_hook.go
+++ b/pkg/module_manager/module_hook.go
@@ -147,7 +147,7 @@ func (h *ModuleHook) Run(bindingType BindingType, context []BindingContext, logL
 	logEntry.Infof("Module hook start %s/%s", h.Module.Name, h.Name)
 
 	for _, info := range h.HookController.SnapshotsInfo() {
-		logEntry.Infof("snapshot info: %s", info)
+		logEntry.Debugf("snapshot info: %s", info)
 	}
 
 	// Convert context for version


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

- set runtime config dependency in operator instance (related: https://github.com/flant/shell-operator/pull/352)
- set debug log level for 'snapshot info' messages (related: https://github.com/flant/shell-operator/pull/376)

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Fix server side error on running `addon-operator config list`, reduce noise in logs.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```