### PR TITLE
fix: restore exponential backoff for failed hooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/flant/kube-client v0.0.6
-	github.com/flant/shell-operator v1.0.11-0.20220615085901-2cc8e0b2351e // branch: fix_exp_backoff
+	github.com/flant/shell-operator v1.0.11-0.20220620115555-adbf8b30f752 // branch: main
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/spec v0.19.8
 	github.com/go-openapi/strfmt v0.19.5

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2a
 github.com/flant/kube-client v0.0.6/go.mod h1:pVKIewJQ5oaBiE6AlTaWAUkd0548DEiyvkqkLaby3Zg=
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a h1:PlStPekqPtTSWDDKFlwgETsT1OiXD1gZtRHcNxAs1lc=
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
-github.com/flant/shell-operator v1.0.11-0.20220615085901-2cc8e0b2351e h1:uwH7haWcVjcsCiUJJxHes5NxsOd5t4XW/S6yjL1Do8I=
-github.com/flant/shell-operator v1.0.11-0.20220615085901-2cc8e0b2351e/go.mod h1:PKefoDxr05PFZjwegIl6v4s1NZjzKZNRbZOe7SyMFuk=
+github.com/flant/shell-operator v1.0.11-0.20220620115555-adbf8b30f752 h1:Tj7SYHkxTYvAukutKieNO41C8MsFZDnr3Ix8fdU5wbA=
+github.com/flant/shell-operator v1.0.11-0.20220620115555-adbf8b30f752/go.mod h1:PKefoDxr05PFZjwegIl6v4s1NZjzKZNRbZOe7SyMFuk=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Restore exponential backoff for delays between failed hooks restarts.


<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

Failed hook restarts every second after merging https://github.com/flant/shell-operator/pull/388 and #315.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```