### PR TITLE
fix: report about modules left to process during the converge

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -1891,6 +1891,12 @@ func (op *AddonOperator) CheckConvergeStatus(t sh_task.Task) {
 
 	// Update field for the first converge.
 	op.UpdateFirstConvergeStatus(convergeTasks)
+
+	// Report modules left to process.
+	if convergeTasks > 0 && (t.GetType() == task.ModuleRun || t.GetType() == task.ModuleDelete) {
+		moduleTasks := ConvergeModulesInQueue(op.TaskQueues.GetMain())
+		log.Infof("Converge modules in progress: %d modules left to process in queue 'main'", moduleTasks)
+	}
 }
 
 // UpdateFirstConvergeStatus checks first converge status and prints log messages if first converge

--- a/pkg/addon-operator/queue.go
+++ b/pkg/addon-operator/queue.go
@@ -59,6 +59,22 @@ func ConvergeTasksInQueue(q *queue.TaskQueue) int {
 	return convergeTasks
 }
 
+func ConvergeModulesInQueue(q *queue.TaskQueue) int {
+	if q == nil {
+		return 0
+	}
+
+	tasks := 0
+	q.Iterate(func(t sh_task.Task) {
+		taskType := t.GetType()
+		if IsConvergeTask(t) && (taskType == task.ModuleRun || taskType == task.ModuleDelete) {
+			tasks++
+		}
+	})
+
+	return tasks
+}
+
 // RemoveCurrentConvergeTasks detects if converge tasks present in the main
 // queue after task which ID equals to 'afterID'. These tasks are drained
 // and the method returns true.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Add message about left ModuleRun/ModuleDelete tasks to process during ConvergeModules.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Restore previous messages "N converge tasks after handle..." in a more predictable way.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

Report only count of ModuleRun and ModuleDelete tasks emerged from ConvergeModules task.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```