### PR TITLE
fix: concurrent map read-write on access module values

### DIFF
--- a/pkg/addon-operator/debug_server.go
+++ b/pkg/addon-operator/debug_server.go
@@ -88,10 +88,10 @@ func RegisterDebugModuleRoutes(dbgSrv *debug.Server, op *AddonOperator) {
 
 		m := op.ModuleManager.GetModule(modName)
 		if m == nil {
-			return nil, fmt.Errorf("Module not found")
+			return nil, fmt.Errorf("Unknown module %s", modName)
 		}
 
-		return m.ValuesPatches(), nil
+		return op.ModuleManager.ModuleDynamicValuesPatches(modName), nil
 	})
 
 	dbgSrv.Route("/module/resource-monitor.{format:(json|yaml)}", func(_ *http.Request) (interface{}, error) {

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -182,7 +182,7 @@ type moduleManager struct {
 	commonStaticValues utils.Values
 
 	// A lock to synchronize access to *ConfigValues and *DynamicValuesPatches maps.
-	valuesLayersLock sync.Mutex
+	valuesLayersLock sync.RWMutex
 
 	// global values from ConfigMap
 	kubeGlobalConfigValues utils.Values
@@ -205,8 +205,6 @@ var _ ModuleManager = &moduleManager{}
 // NewModuleManager returns new MainModuleManager
 func NewModuleManager() *moduleManager {
 	return &moduleManager{
-		valuesLayersLock: sync.Mutex{},
-
 		ValuesValidator: validation.NewValuesValidator(),
 
 		allModulesByName:            make(map[string]*Module),
@@ -1031,15 +1029,15 @@ func (mm *moduleManager) UpdateGlobalDynamicValuesPatches(valuesPatch utils.Valu
 
 // ModuleConfigValues returns config values for module.
 func (mm *moduleManager) ModuleConfigValues(moduleName string) utils.Values {
-	mm.valuesLayersLock.Lock()
-	defer mm.valuesLayersLock.Unlock()
+	mm.valuesLayersLock.RLock()
+	defer mm.valuesLayersLock.RUnlock()
 	return mm.kubeModulesConfigValues[moduleName]
 }
 
 // ModuleConfigValues returns all patches for dynamic values.
 func (mm *moduleManager) ModuleDynamicValuesPatches(moduleName string) []utils.ValuesPatch {
-	mm.valuesLayersLock.Lock()
-	defer mm.valuesLayersLock.Unlock()
+	mm.valuesLayersLock.RLock()
+	defer mm.valuesLayersLock.RUnlock()
 	return mm.modulesDynamicValuesPatches[moduleName]
 }
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -1059,8 +1059,8 @@ func (mm *moduleManager) UpdateModuleDynamicValuesPatches(moduleName string, val
 }
 
 func (mm *moduleManager) ApplyModuleDynamicValuesPatches(moduleName string, values utils.Values) (utils.Values, error) {
-	mm.valuesLayersLock.Lock()
-	defer mm.valuesLayersLock.Unlock()
+	mm.valuesLayersLock.RLock()
+	defer mm.valuesLayersLock.RUnlock()
 
 	var err error
 	res := values

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -71,8 +71,12 @@ type ModuleManager interface {
 	GlobalValuesPatches() []utils.ValuesPatch
 	UpdateGlobalConfigValues(configValues utils.Values)
 	UpdateGlobalDynamicValuesPatches(valuesPatch utils.ValuesPatch)
+
+	ModuleConfigValues(moduleName string) utils.Values
+	ModuleDynamicValuesPatches(moduleName string) []utils.ValuesPatch
 	UpdateModuleConfigValues(moduleName string, configValues utils.Values)
 	UpdateModuleDynamicValuesPatches(moduleName string, valuesPatch utils.ValuesPatch)
+	ApplyModuleDynamicValuesPatches(moduleName string, values utils.Values) (utils.Values, error)
 
 	GetKubeConfigValid() bool
 	SetKubeConfigValid(valid bool)
@@ -177,7 +181,7 @@ type moduleManager struct {
 	// Values from modules/values.yaml file
 	commonStaticValues utils.Values
 
-	// A lock to synchronize access to *ConfigValues and *DynamicValuesPatches fields.
+	// A lock to synchronize access to *ConfigValues and *DynamicValuesPatches maps.
 	valuesLayersLock sync.Mutex
 
 	// global values from ConfigMap
@@ -189,9 +193,6 @@ type moduleManager struct {
 	kubeConfigValid bool
 	// Static and config values are valid using OpenAPI schemas.
 	kubeConfigValuesValid bool
-
-	// Invariant: do not store patches that cannot be applied.
-	// Give user error for patches early, after patch receive.
 
 	// Patches for dynamic global values
 	globalDynamicValuesPatches []utils.ValuesPatch
@@ -1028,6 +1029,20 @@ func (mm *moduleManager) UpdateGlobalDynamicValuesPatches(valuesPatch utils.Valu
 		valuesPatch)
 }
 
+// ModuleConfigValues returns config values for module.
+func (mm *moduleManager) ModuleConfigValues(moduleName string) utils.Values {
+	mm.valuesLayersLock.Lock()
+	defer mm.valuesLayersLock.Unlock()
+	return mm.kubeModulesConfigValues[moduleName]
+}
+
+// ModuleConfigValues returns all patches for dynamic values.
+func (mm *moduleManager) ModuleDynamicValuesPatches(moduleName string) []utils.ValuesPatch {
+	mm.valuesLayersLock.Lock()
+	defer mm.valuesLayersLock.Unlock()
+	return mm.modulesDynamicValuesPatches[moduleName]
+}
+
 // UpdateModuleConfigValues sets updated config values for module.
 func (mm *moduleManager) UpdateModuleConfigValues(moduleName string, configValues utils.Values) {
 	mm.valuesLayersLock.Lock()
@@ -1043,6 +1058,24 @@ func (mm *moduleManager) UpdateModuleDynamicValuesPatches(moduleName string, val
 	mm.modulesDynamicValuesPatches[moduleName] = utils.AppendValuesPatch(
 		mm.modulesDynamicValuesPatches[moduleName],
 		valuesPatch)
+}
+
+func (mm *moduleManager) ApplyModuleDynamicValuesPatches(moduleName string, values utils.Values) (utils.Values, error) {
+	mm.valuesLayersLock.Lock()
+	defer mm.valuesLayersLock.Unlock()
+
+	var err error
+	res := values
+	for _, patch := range mm.modulesDynamicValuesPatches[moduleName] {
+		// Invariant: do not store patches that does not apply
+		// Give user error for patches early, after patch receive
+		res, _, err = utils.ApplyValuesPatch(res, patch, utils.IgnoreNonExistentPaths)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
 }
 
 func (mm *moduleManager) HandleKubeEvent(kubeEvent KubeEvent, createGlobalTaskFn func(*GlobalHook, controller.BindingExecutionInfo), createModuleTaskFn func(*Module, *ModuleHook, controller.BindingExecutionInfo)) {


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Use getters with locks to get module values from ModuleManager.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Fix panic on module values access:

```
fatal error: concurrent map read and map write

goroutine 19695 [running]:
runtime.throw(0x2b4ea10, 0x21)
        /usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc007eea958 sp=0xc007eea928 pc=0x4432b2
runtime.mapaccess1_faststr(0x2626360, 0xc000877260, 0xc000cc22d7, 0x5, 0xc0117758c0)
        /usr/local/go/src/runtime/map_faststr.go:21 +0x465 fp=0xc007eea9c8 sp=0xc007eea958 pc=0x41ed65
github.com/flant/addon-operator/pkg/module_manager.(*Module).Values(0xc000112e60, 0xc000cc22d7, 0x5, 0x0)
        /go/pkg/mod/github.com/flant/addon-operator@v1.0.6-0.20220620123828-eaf343743c09/pkg/module_manager/module.go:741 +0x46b fp=0xc007eeab28 sp=0xc007eea9c8 pc=0x1a6b24b
github.com/flant/addon-operator/pkg/module_manager.(*ModuleHook).Run(0xc011887770, 0x2ad888a, 0x8, 0xc007423ce0, 0x1, 0x1, 0xc00eb4a240, 0xc013ef8030, 0xf10000c004781128, 0x1650933)
        /go/pkg/mod/github.com/flant/addon-operator@v1.0.6-0.20220620123828-eaf343743c09/pkg/module_manager/module_hook.go:261 +0xc1f fp=0xc007eeb0a8 sp=0xc007eeab28 pc=0x1a7161f
github.com/flant/addon-operator/pkg/module_manager.(*moduleManager).RunModuleHook(0xc000886f20, 0x35d831d, 0x34, 0x2ad888a, 0x8, 0xc007423ce0, 0x1, 0x1, 0xc00eb4a240, 0x0, ...)
        /go/pkg/mod/github.com/flant/addon-operator@v1.0.6-0.20220620123828-eaf343743c09/pkg/module_manager/module_manager.go:923 +0x445 fp=0xc007eeb138 sp=0xc007eeb0a8 pc=0x1a7ac45
github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).HandleModuleHookRun(0xc00069e7e0, 0x2f364d8, 0xc0138e7d00, 0xc00eb4a240, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /go/pkg/mod/github.com/flant/addon-operator@v1.0.6-0.20220620123828-eaf343743c09/pkg/addon-operator/operator.go:1479 +0xa0e fp=0xc007eeba10 sp=0xc007eeb138 pc=0x1a9374e
github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).TaskHandler(0xc00069e7e0, 0x2f364d8, 0xc0138e7d00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        
```

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```