### PR TITLE
fix: ignore KubeConfig events before first converge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/flant/kube-client v0.0.6
-	github.com/flant/shell-operator v1.0.11
+	github.com/flant/shell-operator v1.0.12
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-openapi/spec v0.19.8
 	github.com/go-openapi/strfmt v0.19.5

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2a
 github.com/flant/kube-client v0.0.6/go.mod h1:pVKIewJQ5oaBiE6AlTaWAUkd0548DEiyvkqkLaby3Zg=
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a h1:PlStPekqPtTSWDDKFlwgETsT1OiXD1gZtRHcNxAs1lc=
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
-github.com/flant/shell-operator v1.0.11 h1:X8PB/uW2ek9OfZReGG+rxFemqtjEM44WXC4bSq6ynSo=
-github.com/flant/shell-operator v1.0.11/go.mod h1:jX93Qs9VqikWb6PCj0mZHS++DeLx4I3yfuTr5KzvBso=
+github.com/flant/shell-operator v1.0.12 h1:rQhw25F4XcdK+KWgV1AvZHlSjxqD3BEWCfTmFBD2ai4=
+github.com/flant/shell-operator v1.0.12/go.mod h1:jX93Qs9VqikWb6PCj0mZHS++DeLx4I3yfuTr5KzvBso=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/addon-operator/converge.go
+++ b/pkg/addon-operator/converge.go
@@ -10,11 +10,10 @@ import (
 )
 
 type ConvergeState struct {
-	Phase        ConvergePhase
-	FirstStarted bool
-	FirstDone    bool
-	StartedAt    int64
-	Activation   string
+	Phase         ConvergePhase
+	FirstRunPhase FirstConvergePhase
+	StartedAt     int64
+	Activation    string
 }
 
 type ConvergePhase string
@@ -27,9 +26,18 @@ const (
 	WaitAfterAll            ConvergePhase = "WaitAfterAll"
 )
 
+type FirstConvergePhase string
+
+const (
+	FirstNotStarted FirstConvergePhase = "NotStarted"
+	FirstStarted    FirstConvergePhase = "Started"
+	FirstDone       FirstConvergePhase = "Done"
+)
+
 func NewConvergeState() *ConvergeState {
 	return &ConvergeState{
-		Phase: StandBy,
+		Phase:         StandBy,
+		FirstRunPhase: FirstNotStarted,
 	}
 }
 

--- a/pkg/addon-operator/converge.go
+++ b/pkg/addon-operator/converge.go
@@ -26,12 +26,12 @@ const (
 	WaitAfterAll            ConvergePhase = "WaitAfterAll"
 )
 
-type FirstConvergePhase string
+type FirstConvergePhase int
 
 const (
-	FirstNotStarted FirstConvergePhase = "NotStarted"
-	FirstStarted    FirstConvergePhase = "Started"
-	FirstDone       FirstConvergePhase = "Done"
+	FirstNotStarted FirstConvergePhase = iota
+	FirstStarted
+	FirstDone
 )
 
 func NewConvergeState() *ConvergeState {

--- a/pkg/addon-operator/converge.go
+++ b/pkg/addon-operator/converge.go
@@ -11,7 +11,7 @@ import (
 
 type ConvergeState struct {
 	Phase         ConvergePhase
-	FirstRunPhase FirstConvergePhase
+	firstRunPhase firstConvergePhase
 	StartedAt     int64
 	Activation    string
 }
@@ -26,18 +26,18 @@ const (
 	WaitAfterAll            ConvergePhase = "WaitAfterAll"
 )
 
-type FirstConvergePhase int
+type firstConvergePhase int
 
 const (
-	FirstNotStarted FirstConvergePhase = iota
-	FirstStarted
-	FirstDone
+	firstNotStarted firstConvergePhase = iota
+	firstStarted
+	firstDone
 )
 
 func NewConvergeState() *ConvergeState {
 	return &ConvergeState{
 		Phase:         StandBy,
-		FirstRunPhase: FirstNotStarted,
+		firstRunPhase: firstNotStarted,
 	}
 }
 

--- a/pkg/addon-operator/http_server.go
+++ b/pkg/addon-operator/http_server.go
@@ -47,16 +47,16 @@ func RegisterDefaultRoutes(op *AddonOperator) {
 		convergeTasks := ConvergeTasksInQueue(op.TaskQueues.GetMain())
 
 		statusLines := make([]string, 0)
-		switch op.ConvergeState.FirstRunPhase {
-		case FirstNotStarted:
+		switch op.ConvergeState.firstRunPhase {
+		case firstNotStarted:
 			statusLines = append(statusLines, "STARTUP_CONVERGE_NOT_STARTED")
-		case FirstStarted:
+		case firstStarted:
 			if convergeTasks > 0 {
 				statusLines = append(statusLines, fmt.Sprintf("STARTUP_CONVERGE_IN_PROGRESS: %d tasks", convergeTasks))
 			} else {
 				statusLines = append(statusLines, "STARTUP_CONVERGE_DONE")
 			}
-		case FirstDone:
+		case firstDone:
 			statusLines = append(statusLines, "STARTUP_CONVERGE_DONE")
 			if convergeTasks > 0 {
 				statusLines = append(statusLines, fmt.Sprintf("CONVERGE_IN_PROGRESS: %d tasks", convergeTasks))

--- a/pkg/addon-operator/http_server.go
+++ b/pkg/addon-operator/http_server.go
@@ -47,22 +47,21 @@ func RegisterDefaultRoutes(op *AddonOperator) {
 		convergeTasks := ConvergeTasksInQueue(op.TaskQueues.GetMain())
 
 		statusLines := make([]string, 0)
-		if op.IsStartupConvergeDone() {
+		switch op.ConvergeState.FirstRunPhase {
+		case FirstNotStarted:
+			statusLines = append(statusLines, "STARTUP_CONVERGE_NOT_STARTED")
+		case FirstStarted:
+			if convergeTasks > 0 {
+				statusLines = append(statusLines, fmt.Sprintf("STARTUP_CONVERGE_IN_PROGRESS: %d tasks", convergeTasks))
+			} else {
+				statusLines = append(statusLines, "STARTUP_CONVERGE_DONE")
+			}
+		case FirstDone:
 			statusLines = append(statusLines, "STARTUP_CONVERGE_DONE")
 			if convergeTasks > 0 {
 				statusLines = append(statusLines, fmt.Sprintf("CONVERGE_IN_PROGRESS: %d tasks", convergeTasks))
 			} else {
 				statusLines = append(statusLines, "CONVERGE_WAIT_TASK")
-			}
-		} else {
-			if op.ConvergeState.FirstStarted {
-				if convergeTasks > 0 {
-					statusLines = append(statusLines, fmt.Sprintf("STARTUP_CONVERGE_IN_PROGRESS: %d tasks", convergeTasks))
-				} else {
-					statusLines = append(statusLines, "STARTUP_CONVERGE_DONE")
-				}
-			} else {
-				statusLines = append(statusLines, "STARTUP_CONVERGE_WAIT_TASKS")
 			}
 		}
 

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -72,7 +72,7 @@ func (op *AddonOperator) Stop() {
 }
 
 func (op *AddonOperator) IsStartupConvergeDone() bool {
-	return op.ConvergeState.FirstDone
+	return op.ConvergeState.FirstRunPhase == FirstDone
 }
 
 // InitModuleManager initialize KubeConfigManager and ModuleManager,
@@ -111,7 +111,7 @@ func (op *AddonOperator) InitModuleManager() error {
 // AllowHandleScheduleEvent returns false if the Schedule event can be ignored.
 func (op *AddonOperator) AllowHandleScheduleEvent(hook *module_manager.CommonHook) bool {
 	// Always allow if first converge is done.
-	if op.ConvergeState.FirstDone {
+	if op.IsStartupConvergeDone() {
 		return true
 	}
 
@@ -483,6 +483,12 @@ func (op *AddonOperator) HandleConvergeModules(t sh_task.Task, logLabels map[str
 				return
 			}
 
+			// Skip queueing additional Converge tasks during run global hooks at startup.
+			if op.ConvergeState.FirstRunPhase == FirstNotStarted {
+				logEntry.Infof("ConvergeModules: kube config modification detected, ignore until starting first converge")
+				return
+			}
+
 			if len(state.ModulesToReload) > 0 {
 				// Append ModuleRun tasks if ModuleRun is not queued already.
 				reloadTasks := op.CreateReloadModulesTasks(state.ModulesToReload, t.GetLogLabels(), "KubeConfig-Changed-Modules")
@@ -552,8 +558,8 @@ func (op *AddonOperator) HandleConvergeModules(t sh_task.Task, logLabels map[str
 					op.ModuleManager.DisableModuleHooks(moduleName)
 					//op.DrainModuleQueues(moduleName)
 				}
-				// Set ModulesToEnable list to run onStartup hooks for first converge.
-				if !op.ConvergeState.FirstDone {
+				// Set ModulesToEnable list to properly run onStartup hooks for first converge.
+				if !op.IsStartupConvergeDone() {
 					state.ModulesToEnable = state.AllEnabledModules
 				}
 				tasks := op.CreateConvergeModulesTasks(state, t.GetLogLabels(), string(taskEvent))
@@ -1122,6 +1128,7 @@ func (op *AddonOperator) HandleModuleDelete(t sh_task.Task, labels map[string]st
 		err = op.ModuleManager.DeleteModule(hm.ModuleName, t.GetLogLabels())
 	}
 
+	module.State.LastModuleErr = err
 	if err != nil {
 		op.MetricStorage.CounterAdd("{PREFIX}module_delete_errors_total", 1.0, map[string]string{"module": hm.ModuleName})
 		logEntry.Errorf("Module delete failed, requeue task to retry after delay. Failed count is %d. Error: %s", t.GetFailureCount()+1, err)
@@ -1350,6 +1357,7 @@ func (op *AddonOperator) HandleModuleRun(t sh_task.Task, labels map[string]strin
 		valuesChanged, moduleRunErr = module.Run(t.GetLogLabels())
 	}
 
+	module.State.LastModuleErr = moduleRunErr
 	if moduleRunErr != nil {
 		res.Status = queue.Fail
 		logEntry.Errorf("ModuleRun failed in phase '%s'. Requeue task to retry after delay. Failed count is %d. Error: %s", module.State.Phase, t.GetFailureCount()+1, moduleRunErr)
@@ -1482,17 +1490,20 @@ func (op *AddonOperator) HandleModuleHookRun(t sh_task.Task, labels map[string]s
 				allowed = 1.0
 				logEntry.Infof("Module hook failed, but allowed to fail. Error: %v", err)
 				res.Status = queue.Success
+				taskHook.Module.State.SetLastHookErr(hm.HookName, nil)
 			} else {
 				errors = 1.0
 				logEntry.Errorf("Module hook failed, requeue task to retry after delay. Failed count is %d. Error: %s", t.GetFailureCount()+1, err)
 				t.UpdateFailureMessage(err.Error())
 				t.WithQueuedAt(time.Now())
 				res.Status = queue.Fail
+				taskHook.Module.State.SetLastHookErr(hm.HookName, err)
 			}
 		} else {
 			success = 1.0
 			logEntry.Debugf("Module hook success '%s'", hm.HookName)
 			res.Status = queue.Success
+			taskHook.Module.State.SetLastHookErr(hm.HookName, nil)
 
 			// Handle module values change.
 			reloadModule := false
@@ -1902,20 +1913,20 @@ func (op *AddonOperator) CheckConvergeStatus(t sh_task.Task) {
 // UpdateFirstConvergeStatus checks first converge status and prints log messages if first converge
 // is in progress.
 func (op *AddonOperator) UpdateFirstConvergeStatus(convergeTasks int) {
-	if op.ConvergeState.FirstDone {
+	switch op.ConvergeState.FirstRunPhase {
+	case FirstDone:
 		return
-	}
-
-	if convergeTasks > 0 {
-		if !op.ConvergeState.FirstStarted {
-			op.ConvergeState.FirstStarted = true
+	case FirstNotStarted:
+		// Switch to 'started' state if there are 'converge' tasks in the queue.
+		if convergeTasks > 0 {
+			op.ConvergeState.FirstRunPhase = FirstStarted
 		}
-	}
-
-	// First converge is done if started and no converge tasks left in the main queue.
-	if convergeTasks == 0 && op.ConvergeState.FirstStarted {
-		log.Infof("First converge is finished. Operator is ready now.")
-		op.ConvergeState.FirstDone = true
+	case FirstStarted:
+		// Switch to 'done' state after first converge is started and when no 'converge' tasks left in the queue.
+		if convergeTasks == 0 {
+			log.Infof("First converge is finished. Operator is ready now.")
+			op.ConvergeState.FirstRunPhase = FirstDone
+		}
 	}
 }
 

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -72,7 +72,7 @@ func (op *AddonOperator) Stop() {
 }
 
 func (op *AddonOperator) IsStartupConvergeDone() bool {
-	return op.ConvergeState.FirstRunPhase == FirstDone
+	return op.ConvergeState.firstRunPhase == firstDone
 }
 
 // InitModuleManager initialize KubeConfigManager and ModuleManager,
@@ -484,7 +484,7 @@ func (op *AddonOperator) HandleConvergeModules(t sh_task.Task, logLabels map[str
 			}
 
 			// Skip queueing additional Converge tasks during run global hooks at startup.
-			if op.ConvergeState.FirstRunPhase == FirstNotStarted {
+			if op.ConvergeState.firstRunPhase == firstNotStarted {
 				logEntry.Infof("ConvergeModules: kube config modification detected, ignore until starting first converge")
 				return
 			}
@@ -1913,19 +1913,19 @@ func (op *AddonOperator) CheckConvergeStatus(t sh_task.Task) {
 // UpdateFirstConvergeStatus checks first converge status and prints log messages if first converge
 // is in progress.
 func (op *AddonOperator) UpdateFirstConvergeStatus(convergeTasks int) {
-	switch op.ConvergeState.FirstRunPhase {
-	case FirstDone:
+	switch op.ConvergeState.firstRunPhase {
+	case firstDone:
 		return
-	case FirstNotStarted:
+	case firstNotStarted:
 		// Switch to 'started' state if there are 'converge' tasks in the queue.
 		if convergeTasks > 0 {
-			op.ConvergeState.FirstRunPhase = FirstStarted
+			op.ConvergeState.firstRunPhase = firstStarted
 		}
-	case FirstStarted:
+	case firstStarted:
 		// Switch to 'done' state after first converge is started and when no 'converge' tasks left in the queue.
 		if convergeTasks == 0 {
 			log.Infof("First converge is finished. Operator is ready now.")
-			op.ConvergeState.FirstRunPhase = FirstDone
+			op.ConvergeState.firstRunPhase = firstDone
 		}
 	}
 }

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -57,6 +57,7 @@ type ModuleManager interface {
 	GetGlobalHooksNames() []string
 	GetGlobalHook(name string) *GlobalHook
 
+	GetModuleNames() []string
 	GetEnabledModuleNames() []string
 	IsModuleEnabled(moduleName string) bool
 	GetModule(name string) *Module
@@ -715,6 +716,10 @@ func (mm *moduleManager) GetModule(name string) *Module {
 		log.Errorf("Possible bug!!! GetModule: no module '%s' in ModuleManager indexes", name)
 		return nil
 	}
+}
+
+func (mm *moduleManager) GetModuleNames() []string {
+	return mm.allModulesNamesInOrder
 }
 
 func (mm *moduleManager) GetEnabledModuleNames() []string {

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -79,6 +79,8 @@ type ModuleManager interface {
 	UpdateModuleDynamicValuesPatches(moduleName string, valuesPatch utils.ValuesPatch)
 	ApplyModuleDynamicValuesPatches(moduleName string, values utils.Values) (utils.Values, error)
 
+	GetValuesValidator() *validation.ValuesValidator
+
 	GetKubeConfigValid() bool
 	SetKubeConfigValid(valid bool)
 
@@ -1079,6 +1081,10 @@ func (mm *moduleManager) ApplyModuleDynamicValuesPatches(moduleName string, valu
 	}
 
 	return res, nil
+}
+
+func (mm *moduleManager) GetValuesValidator() *validation.ValuesValidator {
+	return mm.ValuesValidator
 }
 
 func (mm *moduleManager) HandleKubeEvent(kubeEvent KubeEvent, createGlobalTaskFn func(*GlobalHook, controller.BindingExecutionInfo), createModuleTaskFn func(*Module, *ModuleHook, controller.BindingExecutionInfo)) {

--- a/pkg/module_manager/module_state.go
+++ b/pkg/module_manager/module_state.go
@@ -27,7 +27,7 @@ type ModuleState struct {
 	Phase                ModuleRunPhase
 	LastModuleErr        error
 	hookErrors           map[string]error
-	hookErrorsLock       sync.Mutex
+	hookErrorsLock       sync.RWMutex
 	synchronizationState *SynchronizationState
 }
 
@@ -53,8 +53,8 @@ func (s *ModuleState) SetLastHookErr(hookName string, err error) {
 
 // GetLastHookErr returns hook error.
 func (s *ModuleState) GetLastHookErr() error {
-	s.hookErrorsLock.Lock()
-	defer s.hookErrorsLock.Unlock()
+	s.hookErrorsLock.RLock()
+	defer s.hookErrorsLock.RUnlock()
 
 	for name, err := range s.hookErrors {
 		if err != nil {

--- a/pkg/module_manager/module_state.go
+++ b/pkg/module_manager/module_state.go
@@ -1,5 +1,10 @@
 package module_manager
 
+import (
+	"fmt"
+	"sync"
+)
+
 type ModuleRunPhase string
 
 const (
@@ -20,16 +25,42 @@ const (
 type ModuleState struct {
 	Enabled              bool
 	Phase                ModuleRunPhase
+	LastModuleErr        error
+	hookErrors           map[string]error
+	hookErrorsLock       sync.Mutex
 	synchronizationState *SynchronizationState
 }
 
 func NewModuleState() *ModuleState {
 	return &ModuleState{
 		Phase:                Startup,
+		hookErrors:           make(map[string]error),
 		synchronizationState: NewSynchronizationState(),
 	}
 }
 
 func (s *ModuleState) Synchronization() *SynchronizationState {
 	return s.synchronizationState
+}
+
+// SetLastHookErr saves error from hook.
+func (s *ModuleState) SetLastHookErr(hookName string, err error) {
+	s.hookErrorsLock.Lock()
+	defer s.hookErrorsLock.Unlock()
+
+	s.hookErrors[hookName] = err
+}
+
+// GetLastHookErr returns hook error.
+func (s *ModuleState) GetLastHookErr() error {
+	s.hookErrorsLock.Lock()
+	defer s.hookErrorsLock.Unlock()
+
+	for name, err := range s.hookErrors {
+		if err != nil {
+			return fmt.Errorf("%s: %v", name, err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/module_manager/testdata/load_and_validate_usage/global/hooks/hook
+++ b/pkg/module_manager/testdata/load_and_validate_usage/global/hooks/hook
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+if [[ "$1" == "--config" ]]; then
+  cat << EOF
+configVersion: v1
+onStartup: 1
+EOF
+fi

--- a/pkg/module_manager/testdata/load_and_validate_usage/global/openapi/config-values.yaml
+++ b/pkg/module_manager/testdata/load_and_validate_usage/global/openapi/config-values.yaml
@@ -1,0 +1,11 @@
+---
+type: object
+default: {}
+additionalProperties: false
+properties:
+  paramStr:
+    type: string
+  paramNum:
+    type: number
+  paramBool:
+    type: boolean

--- a/pkg/module_manager/testdata/load_and_validate_usage/modules/000-test-module/hooks/hook
+++ b/pkg/module_manager/testdata/load_and_validate_usage/modules/000-test-module/hooks/hook
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+if [[ "$1" == "--config" ]]; then
+      cat << EOF
+configVersion: v1
+onStartup: 1
+EOF
+fi

--- a/pkg/module_manager/testdata/load_and_validate_usage/modules/000-test-module/openapi/config-values.yaml
+++ b/pkg/module_manager/testdata/load_and_validate_usage/modules/000-test-module/openapi/config-values.yaml
@@ -1,0 +1,11 @@
+---
+type: object
+default: {}
+additionalProperties: false
+properties:
+  paramStr:
+    type: string
+  paramNum:
+    type: number
+  paramBool:
+    type: boolean


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Supporting changes for https://github.com/deckhouse/deckhouse/pull/1729

- Prevent queueing ConvergeModules while running global hooks at startup
- Add tracking last error for ModuleRun, ModuleDelete and ModuleHookRun
- Add GetModuleNames method
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Global hook in 1729 changes ConfigMap and premature KubeConfigChanged event breaks enabled modules state.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```