### PR TITLE
forbid usage startup and kubernetes bindings together

### DIFF
--- a/sdk/registry.go
+++ b/sdk/registry.go
@@ -55,6 +55,11 @@ func (h *HookRegistry) Add(hook go_hook.GoHook) {
 	h.m.Lock()
 	defer h.m.Unlock()
 
+	config := hook.Config()
+	if config.OnStartup != nil && len(config.Kubernetes) > 0 {
+		panic("OnStartup and Kubernetes bindings cannot be used in a same hook")
+	}
+
 	hookMeta := &go_hook.HookMetadata{}
 
 	pc := make([]uintptr, 50)

--- a/sdk/registry.go
+++ b/sdk/registry.go
@@ -57,7 +57,7 @@ func (h *HookRegistry) Add(hook go_hook.GoHook) {
 
 	config := hook.Config()
 	if config.OnStartup != nil && len(config.Kubernetes) > 0 {
-		panic("OnStartup and Kubernetes bindings cannot be used in a same hook")
+		panic("OnStartup hook always has binding context without Kubernetes snapshots. To prevent logic errors, don't use OnStartup and Kubernetes bindings in the same Go hook configuration.")
 	}
 
 	hookMeta := &go_hook.HookMetadata{}

--- a/sdk/registry.go
+++ b/sdk/registry.go
@@ -8,6 +8,8 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 )
 
+const bindingsPanicMsg = "OnStartup hook always has binding context without Kubernetes snapshots. To prevent logic errors, don't use OnStartup and Kubernetes bindings in the same Go hook configuration."
+
 // /path/.../global-hooks/a/b/c/Hook-name.go
 // $1 - Hook path for sorting (/global/hooks/subdir/v1-hook-onstartup.go)
 // $2 - Hook name for identification (subdir/v1-hook-onstartup.go)
@@ -57,7 +59,7 @@ func (h *HookRegistry) Add(hook go_hook.GoHook) {
 
 	config := hook.Config()
 	if config.OnStartup != nil && len(config.Kubernetes) > 0 {
-		panic("OnStartup hook always has binding context without Kubernetes snapshots. To prevent logic errors, don't use OnStartup and Kubernetes bindings in the same Go hook configuration.")
+		panic(bindingsPanicMsg)
 	}
 
 	hookMeta := &go_hook.HookMetadata{}

--- a/sdk/registry_test.go
+++ b/sdk/registry_test.go
@@ -1,0 +1,74 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegister(t *testing.T) {
+	const panicMsg = "OnStartup hook always has binding context without Kubernetes snapshots. To prevent logic errors, don't use OnStartup and Kubernetes bindings in the same Go hook configuration."
+
+	t.Run("Hook with OnStartup and Kubernetes bindings should panic", func(t *testing.T) {
+		hook := newCommonGoHook(
+			&go_hook.HookConfig{
+				OnStartup: &go_hook.OrderedConfig{Order: 1},
+				Kubernetes: []go_hook.KubernetesConfig{
+					{
+						Name:       "test",
+						ApiVersion: "v1",
+						Kind:       "Pod",
+						FilterFunc: nil,
+					},
+				},
+			},
+			nil,
+		)
+
+		defer func() {
+			r := recover()
+			require.NotEmpty(t, r)
+			assert.Equal(t, panicMsg, r)
+		}()
+		Registry().Add(hook)
+	})
+
+	t.Run("Hook with OnStartup should not panic", func(t *testing.T) {
+		hook := newCommonGoHook(
+			&go_hook.HookConfig{
+				OnStartup: &go_hook.OrderedConfig{Order: 1},
+			},
+			nil,
+		)
+
+		defer func() {
+			r := recover()
+			assert.NotEqual(t, panicMsg, r)
+		}()
+		Registry().Add(hook)
+	})
+
+	t.Run("Hook with Kubernetes binding should not panic", func(t *testing.T) {
+		hook := newCommonGoHook(
+			&go_hook.HookConfig{
+				Kubernetes: []go_hook.KubernetesConfig{
+					{
+						Name:       "test",
+						ApiVersion: "v1",
+						Kind:       "Pod",
+						FilterFunc: nil,
+					},
+				},
+			},
+			nil,
+		)
+
+		defer func() {
+			r := recover()
+			assert.NotEqual(t, panicMsg, r)
+		}()
+		Registry().Add(hook)
+	})
+}

--- a/sdk/registry_test.go
+++ b/sdk/registry_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestRegister(t *testing.T) {
-	const panicMsg = "OnStartup hook always has binding context without Kubernetes snapshots. To prevent logic errors, don't use OnStartup and Kubernetes bindings in the same Go hook configuration."
-
 	t.Run("Hook with OnStartup and Kubernetes bindings should panic", func(t *testing.T) {
 		hook := newCommonGoHook(
 			&go_hook.HookConfig{
@@ -30,7 +28,7 @@ func TestRegister(t *testing.T) {
 		defer func() {
 			r := recover()
 			require.NotEmpty(t, r)
-			assert.Equal(t, panicMsg, r)
+			assert.Equal(t, bindingsPanicMsg, r)
 		}()
 		Registry().Add(hook)
 	})
@@ -45,7 +43,7 @@ func TestRegister(t *testing.T) {
 
 		defer func() {
 			r := recover()
-			assert.NotEqual(t, panicMsg, r)
+			assert.NotEqual(t, bindingsPanicMsg, r)
 		}()
 		Registry().Add(hook)
 	})
@@ -67,7 +65,7 @@ func TestRegister(t *testing.T) {
 
 		defer func() {
 			r := recover()
-			assert.NotEqual(t, panicMsg, r)
+			assert.NotEqual(t, bindingsPanicMsg, r)
 		}()
 		Registry().Add(hook)
 	})


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Forbid usage OnStartup and Kubernetes bindings together

#### What this PR does / why we need it

Hook with onStartup binding could not have kubernetes snapshots. Usually ability to declare them together leads to logic errors. Let's forbid it.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

NONE
