### PR TITLE
fix: support 'map merge' feature for OpenAPI schemas in YAML files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/flant/kube-client v0.0.6
 	github.com/flant/shell-operator v1.0.11
 	github.com/go-chi/chi/v5 v5.0.7
+	github.com/go-openapi/loads v0.19.5
 	github.com/go-openapi/spec v0.19.8
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/swag v0.19.9

--- a/pkg/values/validation/schemas_test.go
+++ b/pkg/values/validation/schemas_test.go
@@ -1,10 +1,13 @@
 package validation
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"testing"
 
+	"github.com/go-openapi/swag"
 	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
 )
 
 func Test_Add_Schema(t *testing.T) {
@@ -20,6 +23,30 @@ func Test_Add_Schema(t *testing.T) {
 
 	s := st.GlobalValuesSchema(ConfigValuesSchema)
 	g.Expect(s).ShouldNot(BeNil(), "schema for config should be in cache")
+
+	res, err := toGJSON(s)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Check own fields.
+	g.Expect(res.Get("properties.clusterName").Exists()).Should(BeTrue(), "should load clusterName, got: %s", res.Raw)
+	g.Expect(res.Get("properties.project.properties.version").Exists()).Should(BeTrue(), "should load project.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.project.properties.name").Exists()).Should(BeTrue(), "should load project.name, got: %s", res.Raw)
+	// Check anchored fields.
+	g.Expect(res.Get("properties.activeProject.properties.version").Exists()).Should(BeTrue(), "should load anchored activeProject.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.archive.items.properties.version").Exists()).Should(BeTrue(), "should load anchored archive.items.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.archive.items.properties.description").Exists()).Should(BeTrue(), "should load archive.items.description, got: %s", res.Raw)
+	// Check ref-ed schema with anchors.
+	g.Expect(res.Get("properties.externalProjects").Exists()).Should(BeTrue(), "should exists 'externalProjects' field")
+	g.Expect(res.Get("properties.externalProjects.properties.activeProject.properties.version").Exists()).Should(BeTrue(), "should load anchored externalProjects.activeProject.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.externalProjects.properties.archive.items.properties.version").Exists()).Should(BeTrue(), "should load anchored externalProjects.archive.items.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.externalProjects.properties.archive.items.properties.description").Exists()).Should(BeTrue(), "should load externalProjects.archive.items.description, got: %s", res.Raw)
+	// Check ref-ed fragment with anchors.
+	g.Expect(res.Get("properties.fragmentedProjects").Exists()).Should(BeTrue(), "should exists 'fragmentedProjects' field")
+	g.Expect(res.Get("properties.fragmentedProjects.properties.activeProject.properties.version").Exists()).Should(BeTrue(), "should load anchored fragmentedProjects.activeProject.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.fragmentedProjects.properties.archive.items.properties.version").Exists()).Should(BeTrue(), "should load anchored and local ref-ed fragmentedProjects.archive.items.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.fragmentedProjects.properties.archive.items.properties.version.type").String()).Should(Equal("number"), "should load type for anchored and local ref-ed fragmentedProjects.archive.items.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.fragmentedProjects.properties.archive.items.properties.description").Exists()).Should(BeTrue(), "should load local ref-ed fragmentedProjects.archive.items.description, got: %s", res.Raw)
+	g.Expect(res.Get("properties.fragmentedProjects.properties.archive.items.properties.description.type").String()).Should(Equal("string"), "should load type for local ref-ed fragmentedProjects.archive.items.description, got: %s", res.Raw)
 
 	s = st.GlobalValuesSchema(ValuesSchema)
 	g.Expect(s).Should(BeNil(), "schema for values should not be in cache")
@@ -40,5 +67,66 @@ func Test_Add_Schema_Bad(t *testing.T) {
 	err = st.AddGlobalValuesSchemas(nil, schemaBytes)
 	t.Logf("%v", err)
 	g.Expect(err).Should(HaveOccurred(), "invalid schema should not be loaded")
+}
 
+func TestMapMergeAnchor(t *testing.T) {
+	// 'project' has two properties: 'name' and 'version', they are "catch" by an anchor.
+	// 'activeProject' uses anchor to "copy" all properties from the 'project'.
+	// 'archive' items are projects with additional property 'descriptio'. So anchor is used
+	// in "merge map" mode to "copy" 'name' and 'version' and then add 'description'.
+	schemaWithMapMerge := `
+type: object
+properties:
+  project:
+    type: object
+    properties: &common_project
+      name:
+        type: string
+      version:
+        type: number
+  activeProject:
+    type: object
+    properties: *common_project
+  archive:
+    type: array
+    items:
+      type: object
+      properties:
+        <<: *common_project
+        description:
+          type: string
+`
+
+	g := NewWithT(t)
+
+	// Check swag loader via yaml.MapSlice.
+	yml, err := swag.BytesToYAMLDoc([]byte(schemaWithMapMerge))
+	g.Expect(err).ShouldNot(HaveOccurred())
+	doc, err := swag.YAMLToJSON(yml)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	res, err := toGJSON(doc)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(res.Get("properties.activeProject.properties.version").Exists()).Should(BeTrue(), "should load anchored activeProject.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.archive.items.properties.version").Exists()).Should(BeFalse(), "WOW! go-openapi/swag is now fixed: it loads anchored archive.items.version, remove additional loader in schemas.go")
+	g.Expect(res.Get("properties.archive.items.properties.description").Exists()).Should(BeTrue(), "should load archive.items.description, got: %s", res.Raw)
+
+	// Check custom loader via interface{}.
+	doc, err = YAMLBytesToJSONDoc([]byte(schemaWithMapMerge))
+	g.Expect(err).ShouldNot(HaveOccurred())
+	res, err = toGJSON(doc)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(res.Get("properties.activeProject.properties.version").Exists()).Should(BeTrue(), "should load anchored activeProject.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.archive.items.properties.version").Exists()).Should(BeTrue(), "should load anchored archive.items.version, got: %s", res.Raw)
+	g.Expect(res.Get("properties.archive.items.properties.description").Exists()).Should(BeTrue(), "should load archive.items.description, got: %s", res.Raw)
+}
+
+func toGJSON(obj interface{}) (*gjson.Result, error) {
+	// Marshal to bytes and put into gjson.
+	schemaBytes, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	res := gjson.ParseBytes(schemaBytes)
+	return &res, nil
 }

--- a/pkg/values/validation/testdata/test-schema-ok-project-2.yaml
+++ b/pkg/values/validation/testdata/test-schema-ok-project-2.yaml
@@ -1,0 +1,31 @@
+# Hide OpenAPI schema inside array to test loading from the $ref-ed fragment.
+# Also test local definitions. Note $ref works from the document root, not
+# from the fragment root (see test-schema-ok.yaml).
+versions:
+- version: v1
+  OpenAPISchema:
+    definitions:
+      version:
+        type: number
+      description:
+        type: string
+    type: object
+    properties:
+      project:
+        type: object
+        properties: &common_project
+          name:
+            type: string
+          version:
+            $ref: '#/versions/0/OpenAPISchema/definitions/version'
+      activeProject:
+        type: object
+        properties: *common_project
+      archive:
+        type: array
+        items:
+          type: object
+          properties:
+            <<: *common_project
+            description:
+              $ref: '#/versions/0/OpenAPISchema/definitions/description'

--- a/pkg/values/validation/testdata/test-schema-ok-project.yaml
+++ b/pkg/values/validation/testdata/test-schema-ok-project.yaml
@@ -1,13 +1,5 @@
 type: object
-additionalProperties: false
-required:
-  - clusterName
-minProperties: 2
 properties:
-  clusterName:
-    type: string
-  clusterHostname:
-    type: string
   project:
     type: object
     properties: &common_project
@@ -26,7 +18,3 @@ properties:
         <<: *common_project
         description:
           type: string
-  externalProjects:
-    $ref: 'testdata/test-schema-ok-project.yaml'
-  fragmentedProjects:
-    $ref: 'testdata/test-schema-ok-project-2.yaml#/versions/0/OpenAPISchema'


### PR DESCRIPTION
#### Overview

go-openapi/swag package uses yaml.MapSlice type to unmarshal from YAML bytes. This type supports 'direct' anchoring (`properties: *anchor`) but doesn't support 'map merge' (`<<: *anchor`). Additional loader is added to unmarshal YAML bytes into interface{}, so 'map merge' is now supported.

Add tests to check for anchor support and also check if $ref is working.

#### What this PR does / why we need it

'map merge' is a convinient feature of YAML format, we use it in CRDs in deckhouse to copy and add properties between objects: [OpenStackClusterConfiguration](https://github.com/deckhouse/deckhouse/blob/main/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml#L206)

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
