### PR TITLE
fix: cannot find ld

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} flant/jq:b6be13d5-musl as libjq
 FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.19-alpine3.15 AS builder
 
 ARG appVersion=latest
-RUN apk --no-cache add git ca-certificates gcc musl-dev libc-dev
+RUN apk --no-cache add git ca-certificates gcc musl-dev libc-dev binutils-gold
 
 # Cache-friendly download of go dependencies.
 ADD go.mod go.sum /app/


### PR DESCRIPTION
#### Overview

Update to alpine-3.15 leads to an error "'cannot find 'ld" during build.



```
#54 [linux/arm/v7 builder 9/9] RUN shellOpVer=$(go list -m all | grep shell-operator | cut -d' ' -f 2-)     CGO_ENABLED=1     CGO_CFLAGS="-I/libjq/include"     CGO_LDFLAGS="-L/libjq/lib"     GOOS=linux     go build -ldflags="-linkmode external -extldflags '-static' -s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$shellOpVer' -X 'github.com/flant/addon-operator/pkg/app.Version=dev-refs/pull/355/merge-d33fc56c-2022.12.21_12:08:37'"              -tags use_libjq              -o addon-operator              ./cmd/addon-operator
#54 3059.1 # github.com/flant/addon-operator/cmd/addon-operator
#54 3059.1 /usr/local/go/pkg/tool/linux_arm/link: running gcc failed: exit status 1
#54 3059.1 collect2: fatal error: cannot find 'ld'
#54 3059.1 compilation terminated.
#54 3059.1 
#54 ERROR: process "/bin/sh -c shellOpVer=$(go list -m all | grep shell-operator | cut -d' ' -f 2-)     CGO_ENABLED=1     CGO_CFLAGS=\"-I/libjq/include\"     CGO_LDFLAGS=\"-L/libjq/lib\"     GOOS=linux     go build -ldflags=\"-linkmode external -extldflags '-static' -s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$shellOpVer' -X 'github.com/flant/addon-operator/pkg/app.Version=$appVersion'\"              -tags use_libjq              -o addon-operator              ./cmd/addon-operator" did not complete successfully: exit code: 2
...
#54 3059.1 # github.com/flant/addon-operator/cmd/addon-operator
#54 3059.1 /usr/local/go/pkg/tool/linux_arm/link: running gcc failed: exit status 1
#54 3059.1 collect2: fatal error: cannot find 'ld'
#54 3059.1 compilation terminated.
#54 3059.1 
------
Dockerfile:23
--------------------
  22 |     
  23 | >>> RUN shellOpVer=$(go list -m all | grep shell-operator | cut -d' ' -f 2-) \
  24 | >>>     CGO_ENABLED=1 \
  25 | >>>     CGO_CFLAGS="-I/libjq/include" \
  26 | >>>     CGO_LDFLAGS="-L/libjq/lib" \
  27 | >>>     GOOS=linux \
  28 | >>>     go build -ldflags="-linkmode external -extldflags '-static' -s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$shellOpVer' -X 'github.com/flant/addon-operator/pkg/app.Version=$appVersion'" \
  29 | >>>              -tags use_libjq \
  30 | >>>              -o addon-operator \
  31 | >>>              ./cmd/addon-operator
  32 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c shellOpVer=$(go list -m all | grep shell-operator | cut -d' ' -f 2-)     CGO_ENABLED=1     CGO_CFLAGS=\"-I/libjq/include\"     CGO_LDFLAGS=\"-L/libjq/lib\"     GOOS=linux     go build -ldflags=\"-linkmode external -extldflags '-static' -s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$shellOpVer' -X 'github.com/flant/addon-operator/pkg/app.Version=$appVersion'\"              -tags use_libjq              -o addon-operator              ./cmd/addon-operator" did not complete successfully: exit code: 2
```

There are some issues:
https://github.com/golang/go/issues/22040
https://github.com/golang/go/issues/57035
https://github.com/golang/go/issues/52399
And may be this one:
https://github.com/golang/go/issues/44703

22040 says everything should work, but installing binutils-gold mentioned in 52339 just helps.


<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->


<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```