### PR TITLE
feat: Persist helm3lib Kubernetes clients

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -33,7 +33,7 @@ func InitHelmClientFactory(kubeClient klient.Client) (*ClientFactory, error) {
 	case Helm3Lib:
 		log.Info("Helm3Lib detected. Use builtin Helm.")
 		factory.NewClientFn = helm3lib.NewClient
-		err = helm3lib.Init(&helm3lib.Options{
+		helm3lib.Init(&helm3lib.Options{
 			Namespace:  app.Namespace,
 			HistoryMax: app.Helm3HistoryMax,
 			Timeout:    app.Helm3Timeout,

--- a/pkg/helm/helm3lib/helm3lib_test.go
+++ b/pkg/helm/helm3lib/helm3lib_test.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/storage"
@@ -85,4 +86,24 @@ func actionConfigFixture(t *testing.T) *action.Configuration {
 			t.Logf(format, v...)
 		},
 	}
+}
+
+// BenchmarkRESTMapper is here to remember that helm does not cache the client by default.
+func BenchmarkRESTMapper(b *testing.B) {
+	ns := "test"
+
+	getterEnv := cli.New().RESTClientGetter()
+	getterPersistent := buildConfigFlagsFromEnv(&ns, cli.New())
+
+	b.Run("Env client", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = getterEnv.ToRESTMapper()
+		}
+	})
+
+	b.Run("Persistent client", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = getterPersistent.ToRESTMapper()
+		}
+	})
 }

--- a/pkg/helm/helm3lib/helm3lib_test.go
+++ b/pkg/helm/helm3lib/helm3lib_test.go
@@ -45,17 +45,14 @@ func TestHelm3LibUpgradeDelete(t *testing.T) {
 }
 
 func initHelmClient(t *testing.T) *LibClient {
-	g := NewWithT(t)
-
 	fCluster := fake.NewFakeCluster(fake.ClusterVersionV125)
 
-	err := Init(&Options{
+	Init(&Options{
 		Namespace:  "test-ns",
 		HistoryMax: 10,
 		Timeout:    0,
 		KubeClient: fCluster.Client,
 	})
-	g.Expect(err).ShouldNot(HaveOccurred())
 
 	actionConfig = actionConfigFixture(t)
 


### PR DESCRIPTION
#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

This PR prevents instantiating the REST client multiple times. In our current configuration, helm discovery actively allocates memory, which makes GC executions more frequent. The full description can be found [here](https://github.com/kubernetes/cli-runtime/blob/4e17abf5754235e5f3adec6b5fcb71a1b6a504d7/pkg/genericclioptions/config_flags.go#L115-L118).

<img width="300" alt="image" src="https://user-images.githubusercontent.com/32434187/232317161-82b2208e-a6be-4d60-91da-bd1ab3650f8e.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/32434187/232317301-46d9be25-fda4-49bd-951a-2a348dfc882b.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/32434187/232317525-e3f83397-ad2c-4a22-8cd0-76e374944b77.png">

Benchmark results for getting the REST client with the previously used env getter and the new persistent getter:

```
goos: darwin
goarch: amd64
pkg: github.com/flant/addon-operator/pkg/helm/helm3lib
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkRESTMapper/Env_client-12                   1413            790653 ns/op          183872 B/op       1939 allocs/op
BenchmarkRESTMapper/Persistent_client-12        44701933             27.69 ns/op               0 B/op          0 allocs/op
```

#### Special notes for your reviewer

Requires deep testing because this can lead to issues in cases when CRDs are deployed to the cluster, which means new resource types are dynamically added to a cluster.

Another way to solve the problem is to use a single client for all operations with Kubernetes.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Persist helm3lib Kubernetes clients.
```