### PR TITLE
List only metadata in resource monitor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/flant/kube-client v0.25.0
+	github.com/flant/kube-client v0.26.1
 	github.com/flant/shell-operator v1.2.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-openapi/loads v0.19.5

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
-github.com/flant/kube-client v0.25.0 h1:7uwwbvGNl3d7jNk0nHM4VxNbTnhESXLTiv/gQaUb9A0=
-github.com/flant/kube-client v0.25.0/go.mod h1:BPNhiy57FgJmnSBXy0l8AwBN6F9SHOfgFgHi3UG2Jrw=
+github.com/flant/kube-client v0.26.1 h1:QIT/Skmdv5Mpu8OWBzncmZdtlKXDKzkyhte7wlXnbVE=
+github.com/flant/kube-client v0.26.1/go.mod h1:BPNhiy57FgJmnSBXy0l8AwBN6F9SHOfgFgHi3UG2Jrw=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee h1:evii83J+/6QGNvyf6tjQ/p27DPY9iftxIBb37ALJRTg=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
 github.com/flant/shell-operator v1.2.0 h1:0KCWZ5IyThN8LFiAK954yXbLLBw6MvPk8bQ+ny3w7E8=

--- a/pkg/helm_resources_manager/resources_monitor.go
+++ b/pkg/helm_resources_manager/resources_monitor.go
@@ -250,7 +250,7 @@ func (r *ResourcesMonitor) listResources(ctx context.Context, nsgvr namespacedGV
 		ResourceVersion:      "0",
 		ResourceVersionMatch: v1.ResourceVersionMatchNotOlderThan,
 	}
-	objList, err := r.kubeClient.Dynamic().Resource(nsgvr.GVR).Namespace(nsgvr.Namespace).List(ctx, listOpts)
+	objList, err := r.kubeClient.Metadata().Resource(nsgvr.GVR).Namespace(nsgvr.Namespace).List(ctx, listOpts)
 	if err != nil {
 		return nil, fmt.Errorf("fetch list for helm resource %s in ns: %s failed: %s", nsgvr.GVR, nsgvr.Namespace, err)
 	}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Helm resource monitor only checks wether objects exist in the cluster or not. Now it uses a dynamic client but only extracts the names of objects. With the metadata client, addon-operator can only get the information needed to make a decision.

#### What this PR does / why we need it

In the standby node, the resource monitor is 1/3 of all allocations.

Before:
<img width="1584" alt="image" src="https://user-images.githubusercontent.com/32434187/236574683-ad465f32-4b43-45e3-90ab-c65180b6e635.png">

After (during converge):
![image](https://user-images.githubusercontent.com/32434187/236669805-7fd3dc71-680d-4502-bab6-2391a1c63b74.png)


#### Special notes for your reviewer

https://pkg.go.dev/k8s.io/client-go/metadata