### PR TITLE
Fix panic on defaulting an array without items schema

### DIFF
--- a/pkg/module_manager/module_manager_test.go
+++ b/pkg/module_manager/module_manager_test.go
@@ -320,7 +320,7 @@ func Test_ModuleManager_LoadValues_ApplyDefaults(t *testing.T) {
 	graf := globVals["grafana"].(string)
 	assert.Equal(t, "grafana", graf)
 
-	// 'azaza' field from modules/values.yaml.
+	// 'testvalue1' field from modules/values.yaml.
 	assert.Contains(t, globVals, "init")
 	initVals := globVals["init"].(map[string]interface{})
 	assert.Contains(t, initVals, "param1")

--- a/pkg/utils/values_patch_test.go
+++ b/pkg/utils/values_patch_test.go
@@ -691,10 +691,10 @@ func Test_jsonpatch_Add_Remove_for_array(t *testing.T) {
 	// 2. Add last element.
 	origDoc = newDoc
 	patch1, _ = DecodePatch([]byte(`
-[{"op":"add", "path":"/root/array/-", "value":"azaza"}]
+[{"op":"add", "path":"/root/array/-", "value":"testvalue1"}]
 `))
 
-	expectNewDoc = []byte(`{"root":{"array":["azaza"]}}`)
+	expectNewDoc = []byte(`{"root":{"array":["testvalue1"]}}`)
 
 	newDoc, err = patch1.Apply(origDoc)
 	g.Expect(err).ShouldNot(HaveOccurred(), "patch 2 apply")
@@ -704,13 +704,13 @@ func Test_jsonpatch_Add_Remove_for_array(t *testing.T) {
 	origDoc = newDoc
 
 	patch1, _ = DecodePatch([]byte(`
-[ {"op":"add", "path":"/root/array/-", "value":"ololo"},
+[ {"op":"add", "path":"/root/array/-", "value":"randomvalue"},
   {"op":"add", "path":"/root/array/-", "value":"foobar"},
   {"op":"add", "path":"/root/array/-", "value":"baz"}
 ]
 `))
 
-	expectNewDoc = []byte(`{"root":{"array":["azaza", "ololo", "foobar", "baz"]}}`)
+	expectNewDoc = []byte(`{"root":{"array":["testvalue1", "randomvalue", "foobar", "baz"]}}`)
 
 	newDoc, err = patch1.Apply(origDoc)
 	g.Expect(err).ShouldNot(HaveOccurred(), "patch 3 apply")
@@ -728,9 +728,9 @@ func Test_jsonpatch_Add_Remove_for_array(t *testing.T) {
 	// "remove 1, remove 2" actually do: "remove 1, remove 3"
 
 	// wrong expectation...
-	// expectNewDoc = []byte(`{"root":{"array":["azaza", "baz"]}}`)
+	// expectNewDoc = []byte(`{"root":{"array":["testvalue1", "baz"]}}`)
 	// Actual result
-	expectNewDoc = []byte(`{"root":{"array":["azaza", "foobar"]}}`)
+	expectNewDoc = []byte(`{"root":{"array":["testvalue1", "foobar"]}}`)
 
 	newDoc, err = patch1.Apply(origDoc)
 	g.Expect(err).ShouldNot(HaveOccurred(), "patch 4 apply")

--- a/pkg/values/validation/defaulting.go
+++ b/pkg/values/validation/defaulting.go
@@ -49,6 +49,13 @@ func ApplyDefaults(obj interface{}, s *spec.Schema) bool {
 			}
 		}
 	case []interface{}:
+		// If the 'items' section is not specified in the schema, addon-operator will panic here.
+		// The schema itself should be validated earlier before applying defaults,
+		// but having a panic in runtime is much bigger problem.
+		if s.Items == nil {
+			return res
+		}
+
 		// Only List validation is supported.
 		// See https://json-schema.org/understanding-json-schema/reference/array.html#list-validation
 		for _, v := range obj {

--- a/pkg/values/validation/defaulting_test.go
+++ b/pkg/values/validation/defaulting_test.go
@@ -19,6 +19,8 @@ func Test_ApplyDefaults(t *testing.T) {
 	moduleValues, err = utils.NewValuesFromBytes([]byte(`
 moduleName:
   param1: val1
+  arrayObjDefaultNoItems:
+  - test1
 `))
 	g.Expect(err).ShouldNot(HaveOccurred())
 
@@ -34,23 +36,23 @@ properties:
     - val1
   param2:
     type: string
-    default: azaza
+    default: testvalue1
   paramObj:
     type: object
     default:
       internal: 
-        azaza: qweqwe
+        testvalue1: qweqwe
   paramObjDeep:
     type: object
     default: {}
     properties:
       param1:
         type: string
-        default: ololo
+        default: randomvalue
   paramObjDeepDeep:
     default:
       deepParam1:
-        param1: ololo
+        param1: randomvalue
     type: object
     properties:
       deepParam1:
@@ -58,6 +60,9 @@ properties:
         properties:
           param1:
             type: string
+  arrayObjDefaultNoItems:
+    default: []
+    type: array
 `
 
 	v := NewValuesValidator()
@@ -81,17 +86,20 @@ properties:
 	q := moduleValues["moduleName"].(map[string]interface{})
 	p := q["paramObj"].(map[string]interface{})
 	p = p["internal"].(map[string]interface{})
-	g.Expect(p).Should(HaveKey("azaza"))
+	g.Expect(p).Should(HaveKey("testvalue1"))
 
 	p = q["paramObjDeep"].(map[string]interface{})
 	g.Expect(p["param1"]).Should(BeAssignableToTypeOf(""))
 	str := p["param1"].(string)
-	g.Expect(str).Should(Equal("ololo"))
+	g.Expect(str).Should(Equal("randomvalue"))
 
 	p = q["paramObjDeepDeep"].(map[string]interface{})
 	p = p["deepParam1"].(map[string]interface{})
 	str = p["param1"].(string)
-	g.Expect(str).Should(Equal("ololo"))
+	g.Expect(str).Should(Equal("randomvalue"))
+
+	a := q["arrayObjDefaultNoItems"].([]interface{})
+	g.Expect(a).Should(Equal([]interface{}{"test1"}))
 }
 
 // defaulter from go-openapi as a reference
@@ -112,23 +120,26 @@ additionalProperties: false
 required:
 - param1
 properties:
+  arrayObjDefaultNoItems:
+    default: ["abc"]
+    type: array
   param1:
     type: string
     enum:
     - val1
   param2:
     type: string
-    default: azaza
+    default: testvalue1
   paramObj:
     type: object
     default:
       internal: 
-        azaza: qweqwe
+        testvalue1: qweqwe
     properties:
       internal:
         type: object
         properties:
-          azaza:
+          testvalue1:
             type: string
   paramObjDeep:
     type: object
@@ -136,7 +147,7 @@ properties:
     properties:
       param1:
         type: string
-        default: ololo
+        default: randomvalue
   paramObjDeepDeep:
     type: object
     default:
@@ -147,7 +158,7 @@ properties:
         properties:
           param1:
             type: string
-            default: ololo
+            default: randomvalue
 `
 
 	v := NewValuesValidator()
@@ -183,14 +194,17 @@ properties:
 	q := moduleValues["moduleName"].(map[string]interface{})
 	p := q["paramObj"].(map[string]interface{})
 	p = p["internal"].(map[string]interface{})
-	g.Expect(p).Should(HaveKey("azaza"))
+	g.Expect(p).Should(HaveKey("testvalue1"))
 
 	p = q["paramObjDeep"].(map[string]interface{})
 	str := p["param1"].(string)
-	g.Expect(str).Should(Equal("ololo"))
+	g.Expect(str).Should(Equal("randomvalue"))
 
 	p = q["paramObjDeepDeep"].(map[string]interface{})
 	p = p["deepParam1"].(map[string]interface{})
 	str = p["param1"].(string)
-	g.Expect(str).Should(Equal("ololo"))
+	g.Expect(str).Should(Equal("randomvalue"))
+
+	a := q["arrayObjDefaultNoItems"].([]interface{})
+	g.Expect(a).Should(Equal([]interface{}{"abc"}))
 }

--- a/pkg/values/validation/validator_test.go
+++ b/pkg/values/validation/validator_test.go
@@ -68,7 +68,7 @@ properties:
     - val1
   param2:
     type: object
-    default: { azaza: qweqweqw }
+    default: { testvalue1: qweqweqw }
     properties:
       aq:
         type: string
@@ -92,8 +92,8 @@ moduleName:
   param1: val1
   paramObj:
     p1:
-      p11: azaza
-      p12: ololo
+      p11: testvalue1
+      p12: randomvalue
       # deep forbidden property
       asd: qwe
     p2:


### PR DESCRIPTION
#### Overview

Fixing a panic in runtime

#### What this PR does / why we need it

Example of the panic message:
```
{"binding":"kubernetesSynchronization","binding.name":"values","event.type":"OperatorStartup","hook":"get_values.py","hook.type":"module","level":"info","module":"op-monitoring","msg":"ModuleHookRun task for Synchronization of 'main' group binding, trigger is OperatorStartup","queue":"monitoring","task.flow":"start","task.id":"2ed74914-7430-4921-aa8b-e5491d1eaa18","time":"2023-09-02T16:51:40Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2e955cb]

goroutine 16835 [running]:
github.com/flant/addon-operator/pkg/values/validation.ApplyDefaults({0x3972340?, 0xc0005bb0b0?}, 0xc005170480)
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/values/validation/defaulting.go:55 +0x48b
github.com/flant/addon-operator/pkg/values/validation.ApplyDefaults({0x3b63dc0?, 0xc000bec7b0?}, 0xc005170240)
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/values/validation/defaulting.go:47 +0x445
github.com/flant/addon-operator/pkg/values/validation.ApplyDefaults({0x3b63dc0?, 0xc000bec780?}, 0xc005170000)
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/values/validation/defaulting.go:47 +0x445
github.com/flant/addon-operator/pkg/values/validation.ApplyDefaults({0x3b63dc0?, 0xc000bec750?}, 0xc0010ed440)
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/values/validation/defaulting.go:47 +0x445
github.com/flant/addon-operator/pkg/values/validation.ApplyDefaults({0x3b63dc0?, 0xc008b7de00?}, 0xc001cd6240)
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/values/validation/defaulting.go:47 +0x445
github.com/flant/addon-operator/pkg/module_manager.(*ApplyDefaultsForModule).Transform(0xc0067cfc80, 0x3b03020?)
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/module_manager/values_defaulting_transformers.go:36 +0x105
github.com/flant/addon-operator/pkg/module_manager.MergeLayers(0xc000cc682c?, {0xc008060ad8, 0x6, 0xc?})
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/module_manager/values_layered.go:27 +0x25c
github.com/flant/addon-operator/pkg/module_manager.(*Module).Values(0xc000473800)
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/module_manager/module.go:692 +0x345
github.com/flant/addon-operator/pkg/module_manager.(*ModuleManager).RunModuleHook(0xc000834ea0?, {0xc00375bdda, 0x1d}, {0x41004d6, 0xa}, {0xc0071e67e0?, 0x1, 0x1}, 0x41004d6?)
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/module_manager/module_manager.go:800 +0x127
github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).HandleModuleHookRun(0xc0004b47e0, {0x46292b8, 0xc00fb9b000}, 0xc0059eed80)
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/addon-operator/operator.go:1513 +0xcdd
github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).TaskHandler(0xc0004b47e0, {0x46292b8, 0xc00fb9b000})
	/go/pkg/mod/github.com/flant/addon-operator@v1.2.0/pkg/addon-operator/operator.go:914 +0x40b
github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start.func1()
	/go/pkg/mod/github.com/flant/shell-operator@v1.3.1/pkg/task/queue/task_queue.go:406 +0x35e
created by github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start
	/go/pkg/mod/github.com/flant/shell-operator@v1.3.1/pkg/task/queue/task_queue.go:387 +0x6f
```

Provided config values schema:
```yaml
clusterIP:
  type: object
    properties:
      externalIPs:
        type: array
        default: []
```

There is no `items` schema in the `externalIPs` block, which causes panic. This PR only protects from the panic without adding schema validations.

#### Special notes for your reviewer
