### PR TITLE
Disable purging unknown helm releases

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -1105,7 +1105,16 @@ func (op *AddonOperator) HandleDiscoverHelmReleases(t sh_task.Task, labels map[s
 		t.WithQueuedAt(time.Now())
 	} else {
 		res.Status = queue.Success
-		tasks := op.CreatePurgeTasks(state.ModulesToPurge, t)
+		// TODO(nabokihms): This is a temporary workaround to prevent deckhouse deleting modules downloaded from sources.
+		// Purging modules is required to delete releases for modules that were renamed or deleted in a new release.
+		//
+		// However, because of a race between downloading modules and running installation tasks on multimaster clusters.
+		//
+		// In the future, we need to identify and figure out how to handle this race.
+		// Users want to rely that their modules will not be deleted.
+		log.Debugf("Modules to purge found (but they will not be purged): %v", state.ModulesToPurge)
+
+		tasks := op.CreatePurgeTasks([]string{}, t)
 		res.AfterTasks = tasks
 		op.logTaskAdd(logEntry, "after", res.AfterTasks...)
 	}

--- a/pkg/addon-operator/operator_test.go
+++ b/pkg/addon-operator/operator_test.go
@@ -295,7 +295,7 @@ func Test_Operator_ConvergeModules_main_queue_only(t *testing.T) {
 
 		// TODO DiscoverHelmReleases can add ModulePurge tasks.
 		{task.DiscoverHelmReleases, "", "", ""},
-		{task.ModulePurge, "", moduleToPurge, ""},
+		// {task.ModulePurge, "", moduleToPurge, ""},
 
 		// ConvergeModules runs after global Synchronization and emerges BeforeAll tasks.
 		{task.ConvergeModules, "", "", string(StandBy)},


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Pint modules to purge, but do not purge them

#### What this PR does / why we need it

Purging modules is required to delete releases for modules that were renamed or deleted in a new release.

However, because of a race between downloading modules and running installation tasks on multimaster clusters.

In the future, we need to identify and figure out how to handle this race. Users want to ensure that their modules will not be deleted.

#### Special notes for your reviewer
