### PR TITLE
Update mergemap to reduce memory allocations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/go-openapi/validate v0.19.12
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kennygrant/sanitize v1.2.4
+	github.com/nabokihms/mergemap v0.0.1
 	github.com/onsi/gomega v1.27.10
-	github.com/peterbourgon/mergemap v0.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/segmentio/go-camelcase v0.0.0-20160726192923-7085f1e3c734

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-openapi/validate v0.19.12
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kennygrant/sanitize v1.2.4
-	github.com/nabokihms/mergemap v0.0.1
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -526,6 +526,8 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nabokihms/mergemap v0.0.1 h1:ytuvBnRTiaGaHuQg/XaI+anqBErngo4mlm3qck47178=
+github.com/nabokihms/mergemap v0.0.1/go.mod h1:ckiwPyt9qm7yZEcdvNLy3dEwsi7zexyqo54pR4BMowM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
@@ -543,8 +545,6 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/peterbourgon/mergemap v0.0.1 h1:5/brtSACv34REV0xoYjPQ8JXZnx3nurGt6WInLRwqX4=
-github.com/peterbourgon/mergemap v0.0.1/go.mod h1:jQyRpOpE/KbvPc0VKXjAqctYglwUO5W6zAcGcFfbvlo=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,6 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nabokihms/mergemap v0.0.1 h1:ytuvBnRTiaGaHuQg/XaI+anqBErngo4mlm3qck47178=
-github.com/nabokihms/mergemap v0.0.1/go.mod h1:ckiwPyt9qm7yZEcdvNLy3dEwsi7zexyqo54pR4BMowM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=

--- a/pkg/utils/mergemap.go
+++ b/pkg/utils/mergemap.go
@@ -4,9 +4,7 @@ import (
 	"reflect"
 )
 
-var (
-	MaxDepth = 32
-)
+const maxDepth = 32
 
 // mergeMap recursively merges the src and dst maps. Key conflicts are resolved by
 // preferring src, or recursively descending, if both src and dst are maps.
@@ -15,7 +13,7 @@ func mergeMap(dst, src map[string]interface{}) map[string]interface{} {
 }
 
 func merge(dst, src map[string]interface{}, depth int) map[string]interface{} {
-	if depth > MaxDepth {
+	if depth > maxDepth {
 		panic("too deep!")
 	}
 	for key, srcVal := range src {
@@ -32,11 +30,11 @@ func merge(dst, src map[string]interface{}, depth int) map[string]interface{} {
 }
 
 func mapify(i interface{}) (map[string]interface{}, bool) {
-	switch i.(type) {
+	switch v := i.(type) {
 	case map[string]interface{}:
-		return i.(map[string]interface{}), true
+		return v, true
 	case Values:
-		return i.(Values), true
+		return v, true
 	}
 
 	value := reflect.ValueOf(i)

--- a/pkg/utils/mergemap.go
+++ b/pkg/utils/mergemap.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"reflect"
+)
+
+var (
+	MaxDepth = 32
+)
+
+// mergeMap recursively merges the src and dst maps. Key conflicts are resolved by
+// preferring src, or recursively descending, if both src and dst are maps.
+func mergeMap(dst, src map[string]interface{}) map[string]interface{} {
+	return merge(dst, src, 0)
+}
+
+func merge(dst, src map[string]interface{}, depth int) map[string]interface{} {
+	if depth > MaxDepth {
+		panic("too deep!")
+	}
+	for key, srcVal := range src {
+		if dstVal, ok := dst[key]; ok {
+			srcMap, srcMapOk := mapify(srcVal)
+			dstMap, dstMapOk := mapify(dstVal)
+			if srcMapOk && dstMapOk {
+				srcVal = merge(dstMap, srcMap, depth+1)
+			}
+		}
+		dst[key] = srcVal
+	}
+	return dst
+}
+
+func mapify(i interface{}) (map[string]interface{}, bool) {
+	switch i.(type) {
+	case map[string]interface{}:
+		return i.(map[string]interface{}), true
+	case Values:
+		return i.(Values), true
+	}
+
+	value := reflect.ValueOf(i)
+	if value.Kind() == reflect.Map {
+		m := make(map[string]interface{}, value.Len())
+		for _, k := range value.MapKeys() {
+			m[k.String()] = value.MapIndex(k).Interface()
+		}
+		return m, true
+	}
+	return map[string]interface{}{}, false
+}

--- a/pkg/utils/mergemap_test.go
+++ b/pkg/utils/mergemap_test.go
@@ -83,7 +83,7 @@ func checkMergedValues(t *testing.T, expected, got map[string]interface{}) {
 		t.Error(err)
 		return
 	}
-	if bytes.Compare(expectedBuf, gotBuf) != 0 {
+	if !bytes.Equal(expectedBuf, gotBuf) {
 		t.Errorf("expected %s, got %s", string(expectedBuf), string(gotBuf))
 		return
 	}

--- a/pkg/utils/mergemap_test.go
+++ b/pkg/utils/mergemap_test.go
@@ -1,0 +1,127 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestMergeMap(t *testing.T) {
+	for _, tuple := range []struct {
+		src      string
+		dst      string
+		expected string
+	}{
+		{
+			src:      `{}`,
+			dst:      `{}`,
+			expected: `{}`,
+		},
+		{
+			src:      `{"b":2}`,
+			dst:      `{"a":1}`,
+			expected: `{"a":1,"b":2}`,
+		},
+		{
+			src:      `{"a":0}`,
+			dst:      `{"a":1}`,
+			expected: `{"a":0}`,
+		},
+		{
+			src:      `{"a":{       "y":2}}`,
+			dst:      `{"a":{"x":1       }}`,
+			expected: `{"a":{"x":1, "y":2}}`,
+		},
+		{
+			src:      `{"a":{"x":2}}`,
+			dst:      `{"a":{"x":1}}`,
+			expected: `{"a":{"x":2}}`,
+		},
+		{
+			src:      `{"a":{       "y":7, "z":8}}`,
+			dst:      `{"a":{"x":1, "y":2       }}`,
+			expected: `{"a":{"x":1, "y":7, "z":8}}`,
+		},
+		{
+			src:      `{"1": { "b":1, "2": { "3": {         "b":3, "n":[1,2]} }        }}`,
+			dst:      `{"1": {        "2": { "3": {"a":"A",        "n":"xxx"} }, "a":3 }}`,
+			expected: `{"1": { "b":1, "2": { "3": {"a":"A", "b":3, "n":[1,2]} }, "a":3 }}`,
+		},
+	} {
+		var dst map[string]interface{}
+		if err := json.Unmarshal([]byte(tuple.dst), &dst); err != nil {
+			t.Error(err)
+			continue
+		}
+
+		var src map[string]interface{}
+		if err := json.Unmarshal([]byte(tuple.src), &src); err != nil {
+			t.Error(err)
+			continue
+		}
+
+		var expected map[string]interface{}
+		if err := json.Unmarshal([]byte(tuple.expected), &expected); err != nil {
+			t.Error(err)
+			continue
+		}
+
+		got := mergeMap(dst, src)
+		checkMergedValues(t, expected, got)
+	}
+}
+
+func checkMergedValues(t *testing.T, expected, got map[string]interface{}) {
+	expectedBuf, err := json.Marshal(expected)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	gotBuf, err := json.Marshal(got)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if bytes.Compare(expectedBuf, gotBuf) != 0 {
+		t.Errorf("expected %s, got %s", string(expectedBuf), string(gotBuf))
+		return
+	}
+}
+
+func BenchmarkMapify(b *testing.B) {
+	k := 100000
+
+	m := make(map[string]interface{}, k)
+	for i := 0; i < k; i++ {
+		m[fmt.Sprintf("long%d", i)] = "storyshort"
+	}
+
+	c := make(map[string]string, k)
+	for i := 0; i < k; i++ {
+		c[fmt.Sprintf("long%d", i)] = "storyshort"
+	}
+
+	a := make(Values, k)
+	for i := 0; i < k; i++ {
+		a[fmt.Sprintf("long%d", i)] = "storyshort"
+	}
+
+	b.Run("Map interface", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			mapify(m)
+		}
+	})
+
+	b.Run("Map string", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			mapify(c)
+		}
+	})
+
+	b.Run("Map Values", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			mapify(a)
+		}
+	})
+}

--- a/pkg/utils/values.go
+++ b/pkg/utils/values.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/nabokihms/mergemap"
 	"github.com/segmentio/go-camelcase"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -101,7 +100,7 @@ func MergeValues(values ...Values) Values {
 	res := make(Values)
 
 	for _, v := range values {
-		res = mergemap.Merge(res, v)
+		res = mergeMap(res, v)
 	}
 
 	return res

--- a/pkg/utils/values.go
+++ b/pkg/utils/values.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/peterbourgon/mergemap"
+	"github.com/nabokihms/mergemap"
 	"github.com/segmentio/go-camelcase"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

The idea is to allocate less memory when the map is already a map[string]interface{} / Values type.

#### What this PR does / why we need it

I decided to move the code to our repo, because
1. This is a single file with two functions, the size is not big enough 
2.  Code changes were required
3. To effectively check type aliases such as `Values`, the type should be imported and be used by the function (causing cyclo dependencies)

#### Special notes for your reviewer

```
goos: darwin
goarch: amd64
pkg: github.com/peterbourgon/mergemap
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                        │       old.txt       │                new.txt                │
                        │       sec/op        │    sec/op     vs base                 │
Mapify/Map_interface-12   45830274.000n ±  9%   2.558n ±  1%  -100.00% (p=0.000 n=20)
Mapify/Map_string-12             51.12m ± 10%   40.15m ± 16%   -21.46% (p=0.000 n=20)

                        │   old.txt    │                  new.txt                  │
                        │     B/op     │     B/op      vs base                     │
Mapify/Map_interface-12   15.49Mi ± 0%    0.00Mi ± 0%  -100.00% (p=0.000 n=20)
Mapify/Map_string-12      15.48Mi ± 0%   10.31Mi ± 0%   -33.39% (p=0.000 n=20)

                        │   old.txt   │                 new.txt                  │
                        │  allocs/op  │  allocs/op   vs base                     │
Mapify/Map_interface-12   203.9k ± 0%     0.0k ± 0%  -100.00% (p=0.000 n=20)
Mapify/Map_string-12      203.9k ± 0%   201.7k ± 0%    -1.11% (p=0.000 n=20)
```