### PR TITLE
Dynamic values patch improvements

### DIFF
--- a/pkg/module_manager/go_hook/patchable_values.go
+++ b/pkg/module_manager/go_hook/patchable_values.go
@@ -61,10 +61,17 @@ func (p *PatchableValues) ArrayCount(path string) (int, error) {
 }
 
 func (p *PatchableValues) Set(path string, value interface{}) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		// The struct returned from a Go hook expected to be marshalable in all cases.
+		// TODO(nabokihms): return a meaningful error.
+		return
+	}
+
 	op := &utils.ValuesPatchOperation{
 		Op:    "add",
 		Path:  convertDotFilePathToSlashPath(path),
-		Value: value,
+		Value: data,
 	}
 
 	p.patchOperations = append(p.patchOperations, op)

--- a/pkg/module_manager/go_hook/patchable_values.go
+++ b/pkg/module_manager/go_hook/patchable_values.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 
 	"github.com/flant/addon-operator/pkg/utils"
@@ -65,6 +66,7 @@ func (p *PatchableValues) Set(path string, value interface{}) {
 	if err != nil {
 		// The struct returned from a Go hook expected to be marshalable in all cases.
 		// TODO(nabokihms): return a meaningful error.
+		log.Errorf("patch path %s: %v\n", path, err)
 		return
 	}
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -1137,7 +1137,7 @@ func (mm *ModuleManager) ApplyEnabledPatch(enabledPatch utils.ValuesPatch) error
 		case "add":
 			v, err := utils.ModuleEnabledValue(op.Value)
 			if err != nil {
-				return fmt.Errorf("apply enabled patch operation '%s' for %s: ", op.Op, op.Path)
+				return fmt.Errorf("apply enabled patch operation '%s' for %s: %v", op.Op, op.Path, err)
 			}
 			log.Debugf("apply dynamic enable: module %s set to '%v'", modName, *v)
 			newDynamicEnabled[modName] = v

--- a/pkg/utils/module_config.go
+++ b/pkg/utils/module_config.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -197,6 +198,14 @@ func ModuleEnabledValue(i interface{}) (*bool, error) {
 	switch v := i.(type) {
 	case string:
 		switch strings.ToLower(v) {
+		case "true":
+			return &ModuleEnabled, nil
+		case "false":
+			return &ModuleDisabled, nil
+		}
+	// TODO(nabokihms): we only need to check the json.RawMessage after the patch refactoring.
+	case json.RawMessage:
+		switch strings.ToLower(string(v)) {
 		case "true":
 			return &ModuleEnabled, nil
 		case "false":

--- a/pkg/utils/values_patch.go
+++ b/pkg/utils/values_patch.go
@@ -88,9 +88,9 @@ func (p *ValuesPatch) MergeOperations(src *ValuesPatch) {
 }
 
 type ValuesPatchOperation struct {
-	Op    string      `json:"op,omitempty"`
-	Path  string      `json:"path,omitempty"`
-	Value interface{} `json:"value,omitempty"`
+	Op    string          `json:"op,omitempty"`
+	Path  string          `json:"path,omitempty"`
+	Value json.RawMessage `json:"value,omitempty"`
 }
 
 func (op *ValuesPatchOperation) ToString() string {

--- a/pkg/utils/values_patch_test.go
+++ b/pkg/utils/values_patch_test.go
@@ -55,7 +55,7 @@ func Test_ApplyValuesPatch(t *testing.T) {
 					{
 						Op:    "add",
 						Path:  "/test_key_3",
-						Value: "baz",
+						Value: []byte(`"baz"`),
 					},
 				},
 			},
@@ -77,7 +77,7 @@ func Test_ApplyValuesPatch(t *testing.T) {
 					{
 						Op:    "remove",
 						Path:  "/test_key_3",
-						Value: "baz",
+						Value: []byte(`"baz"`),
 					},
 				},
 			},
@@ -98,7 +98,7 @@ func Test_ApplyValuesPatch(t *testing.T) {
 					{
 						Op:    "add",
 						Path:  "/test_key_3",
-						Value: "baz",
+						Value: []byte(`"baz"`),
 					},
 					{
 						Op:   "remove",
@@ -107,7 +107,7 @@ func Test_ApplyValuesPatch(t *testing.T) {
 					{
 						Op:    "add",
 						Path:  "/test_key_3",
-						Value: "baz",
+						Value: []byte(`"baz"`),
 					},
 					{
 						Op:   "remove",
@@ -116,7 +116,7 @@ func Test_ApplyValuesPatch(t *testing.T) {
 					{
 						Op:    "add",
 						Path:  "/test_key_3",
-						Value: "baz",
+						Value: []byte(`"baz"`),
 					},
 				},
 			},
@@ -165,7 +165,7 @@ func Test_ApplyValuesPatch_Strict(t *testing.T) {
 					{
 						Op:    "remove",
 						Path:  "/test_key_3",
-						Value: "baz",
+						Value: []byte(`"baz"`),
 					},
 				},
 			},
@@ -181,7 +181,7 @@ func Test_ApplyValuesPatch_Strict(t *testing.T) {
 					{
 						Op:    "add",
 						Path:  "/test_key_3",
-						Value: "baz",
+						Value: []byte(`"baz"`),
 					},
 					{
 						Op:   "remove",
@@ -190,7 +190,7 @@ func Test_ApplyValuesPatch_Strict(t *testing.T) {
 					{
 						Op:    "add",
 						Path:  "/test_key_3",
-						Value: "baz",
+						Value: []byte(`"baz"`),
 					},
 					{
 						Op:   "remove",
@@ -199,7 +199,7 @@ func Test_ApplyValuesPatch_Strict(t *testing.T) {
 					{
 						Op:    "add",
 						Path:  "/test_key_3",
-						Value: "baz",
+						Value: []byte(`"baz"`),
 					},
 				},
 			},


### PR DESCRIPTION
#### Overview

There are some problems with the ApplyModuleDynamicValuesPatch:
* It marshals values to json for every patch
* All patches stored as a pure interface and also marshaled every time as well

#### What this PR does / why we need it


For the first issue, we can compose a patch set before applying it so all the values struct will be marshaled only once for all patches. For the second problem, we can store an object we want to add / change as a raw json message, so the patch is marshaled only once when returned (or not marshalled at all for python / bash hooks).

#### Special notes for your reviewer
