### PR TITLE
[Addon-operator ] Add debug routes

### DIFF
--- a/pkg/addon-operator/bootstrap.go
+++ b/pkg/addon-operator/bootstrap.go
@@ -50,6 +50,7 @@ func (op *AddonOperator) Assemble(debugServer *debug.Server) (err error) {
 	op.engine.RegisterDebugConfigRoutes(debugServer, op.runtimeConfig)
 	op.RegisterDebugGlobalRoutes(debugServer)
 	op.RegisterDebugModuleRoutes(debugServer)
+	op.RegisterDiscoveryRoute(debugServer)
 
 	err = op.InitModuleManager()
 	if err != nil {

--- a/pkg/addon-operator/debug_server.go
+++ b/pkg/addon-operator/debug_server.go
@@ -22,9 +22,9 @@ func (op *AddonOperator) RegisterDebugGlobalRoutes(dbgSrv *debug.Server) {
 		buf := bytes.NewBuffer(nil)
 		walkFn := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
 			if strings.HasPrefix(route, "/global/") {
+				_, _ = fmt.Fprintf(buf, "%s %s\n", method, route)
 				return nil
 			}
-			_, _ = fmt.Fprintf(buf, "%s %s\n", method, route)
 			return nil
 		}
 
@@ -68,7 +68,21 @@ func (op *AddonOperator) RegisterDebugGlobalRoutes(dbgSrv *debug.Server) {
 
 func (op *AddonOperator) RegisterDebugModuleRoutes(dbgSrv *debug.Server) {
 	dbgSrv.RegisterHandler(http.MethodGet, "/module/discovery", func(_ *http.Request) (interface{}, error) {
-		return "TEST /module/discovery", nil
+		buf := bytes.NewBuffer(nil)
+		walkFn := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+			if strings.HasPrefix(route, "/module/") {
+				_, _ = fmt.Fprintf(buf, "%s %s\n", method, route)
+				return nil
+			}
+			return nil
+		}
+
+		err := chi.Walk(dbgSrv.Router, walkFn)
+		if err != nil {
+			return nil, err
+		}
+
+		return buf, nil
 	})
 
 	dbgSrv.RegisterHandler(http.MethodGet, "/module/list.{format:(json|yaml|text)}", func(_ *http.Request) (interface{}, error) {

--- a/pkg/addon-operator/debug_server.go
+++ b/pkg/addon-operator/debug_server.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (op *AddonOperator) RegisterDebugGlobalRoutes(dbgSrv *debug.Server) {
-	dbgSrv.RegisterHandler(http.MethodGet, "/global/discovery", func(request *http.Request) (interface{}, error) {
+	dbgSrv.RegisterHandler(http.MethodGet, "/global/discovery", func(_ *http.Request) (interface{}, error) {
 		buf := bytes.NewBuffer(nil)
 		walkFn := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
 			if strings.HasPrefix(route, "/global/") {
@@ -28,18 +28,11 @@ func (op *AddonOperator) RegisterDebugGlobalRoutes(dbgSrv *debug.Server) {
 			return nil
 		}
 
-		// request.Write()
-
 		err := chi.Walk(dbgSrv.Router, walkFn)
 		if err != nil {
-			// writer.WriteHeader(http.StatusInternalServerError)
-			// return
 			return nil, err
 		}
 
-		// writer.WriteHeader(http.StatusOK)
-		// _, _ = writer.Write(buf.Bytes())
-		// _ = request.Write(buf)
 		return buf, nil
 	})
 
@@ -74,29 +67,8 @@ func (op *AddonOperator) RegisterDebugGlobalRoutes(dbgSrv *debug.Server) {
 }
 
 func (op *AddonOperator) RegisterDebugModuleRoutes(dbgSrv *debug.Server) {
-	dbgSrv.RegisterHandler(http.MethodGet, "/module/discovery", func(request *http.Request) (interface{}, error) {
-		buf := bytes.NewBuffer(nil)
-		walkFn := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
-			if strings.HasPrefix(route, "/module/") {
-				return nil
-			}
-			_, _ = fmt.Fprintf(buf, "%s %s\n", method, route)
-			return nil
-		}
-
-		// request.Write()
-
-		err := chi.Walk(dbgSrv.Router, walkFn)
-		if err != nil {
-			// writer.WriteHeader(http.StatusInternalServerError)
-			// return
-			return nil, err
-		}
-
-		// writer.WriteHeader(http.StatusOK)
-		// _, _ = writer.Write(buf.Bytes())
-		// _ = request.Write(buf)
-		return buf, nil
+	dbgSrv.RegisterHandler(http.MethodGet, "/module/discovery", func(_ *http.Request) (interface{}, error) {
+		return "TEST /module/discovery", nil
 	})
 
 	dbgSrv.RegisterHandler(http.MethodGet, "/module/list.{format:(json|yaml|text)}", func(_ *http.Request) (interface{}, error) {

--- a/pkg/addon-operator/debug_server.go
+++ b/pkg/addon-operator/debug_server.go
@@ -18,24 +18,6 @@ import (
 )
 
 func (op *AddonOperator) RegisterDebugGlobalRoutes(dbgSrv *debug.Server) {
-	dbgSrv.RegisterHandler(http.MethodGet, "/global/discovery", func(_ *http.Request) (interface{}, error) {
-		buf := bytes.NewBuffer(nil)
-		walkFn := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
-			if strings.HasPrefix(route, "/global/") {
-				_, _ = fmt.Fprintf(buf, "%s %s\n", method, route)
-				return nil
-			}
-			return nil
-		}
-
-		err := chi.Walk(dbgSrv.Router, walkFn)
-		if err != nil {
-			return nil, err
-		}
-
-		return buf, nil
-	})
-
 	dbgSrv.RegisterHandler(http.MethodGet, "/global/list.{format:(json|yaml)}", func(_ *http.Request) (interface{}, error) {
 		return map[string]interface{}{
 			"globalHooks": op.ModuleManager.GetGlobalHooksNames(),
@@ -67,24 +49,6 @@ func (op *AddonOperator) RegisterDebugGlobalRoutes(dbgSrv *debug.Server) {
 }
 
 func (op *AddonOperator) RegisterDebugModuleRoutes(dbgSrv *debug.Server) {
-	dbgSrv.RegisterHandler(http.MethodGet, "/module/discovery", func(_ *http.Request) (interface{}, error) {
-		buf := bytes.NewBuffer(nil)
-		walkFn := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
-			if strings.HasPrefix(route, "/module/") {
-				_, _ = fmt.Fprintf(buf, "%s %s\n", method, route)
-				return nil
-			}
-			return nil
-		}
-
-		err := chi.Walk(dbgSrv.Router, walkFn)
-		if err != nil {
-			return nil, err
-		}
-
-		return buf, nil
-	})
-
 	dbgSrv.RegisterHandler(http.MethodGet, "/module/list.{format:(json|yaml|text)}", func(_ *http.Request) (interface{}, error) {
 		mods := op.ModuleManager.GetEnabledModuleNames()
 		sort.Strings(mods)
@@ -200,5 +164,25 @@ func (op *AddonOperator) RegisterDebugModuleRoutes(dbgSrv *debug.Server) {
 		}
 
 		return snapshots, nil
+	})
+}
+
+func (op *AddonOperator) RegisterDiscoveryRoute(dbgSrv *debug.Server) {
+	dbgSrv.RegisterHandler(http.MethodGet, "/discovery", func(_ *http.Request) (interface{}, error) {
+		buf := bytes.NewBuffer(nil)
+		walkFn := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+			if strings.HasPrefix(route, "/global/") || strings.HasPrefix(route, "/module/") {
+				_, _ = fmt.Fprintf(buf, "%s %s\n", method, route)
+				return nil
+			}
+			return nil
+		}
+
+		err := chi.Walk(dbgSrv.Router, walkFn)
+		if err != nil {
+			return nil, err
+		}
+
+		return buf, nil
 	})
 }

--- a/pkg/addon-operator/debug_server.go
+++ b/pkg/addon-operator/debug_server.go
@@ -1,10 +1,12 @@
 package addon_operator
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -16,6 +18,31 @@ import (
 )
 
 func (op *AddonOperator) RegisterDebugGlobalRoutes(dbgSrv *debug.Server) {
+	dbgSrv.RegisterHandler(http.MethodGet, "/global/discovery", func(request *http.Request) (interface{}, error) {
+		buf := bytes.NewBuffer(nil)
+		walkFn := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+			if strings.HasPrefix(route, "/global/") {
+				return nil
+			}
+			_, _ = fmt.Fprintf(buf, "%s %s\n", method, route)
+			return nil
+		}
+
+		// request.Write()
+
+		err := chi.Walk(dbgSrv.Router, walkFn)
+		if err != nil {
+			// writer.WriteHeader(http.StatusInternalServerError)
+			// return
+			return nil, err
+		}
+
+		// writer.WriteHeader(http.StatusOK)
+		// _, _ = writer.Write(buf.Bytes())
+		// _ = request.Write(buf)
+		return buf, nil
+	})
+
 	dbgSrv.RegisterHandler(http.MethodGet, "/global/list.{format:(json|yaml)}", func(_ *http.Request) (interface{}, error) {
 		return map[string]interface{}{
 			"globalHooks": op.ModuleManager.GetGlobalHooksNames(),
@@ -47,6 +74,31 @@ func (op *AddonOperator) RegisterDebugGlobalRoutes(dbgSrv *debug.Server) {
 }
 
 func (op *AddonOperator) RegisterDebugModuleRoutes(dbgSrv *debug.Server) {
+	dbgSrv.RegisterHandler(http.MethodGet, "/module/discovery", func(request *http.Request) (interface{}, error) {
+		buf := bytes.NewBuffer(nil)
+		walkFn := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+			if strings.HasPrefix(route, "/module/") {
+				return nil
+			}
+			_, _ = fmt.Fprintf(buf, "%s %s\n", method, route)
+			return nil
+		}
+
+		// request.Write()
+
+		err := chi.Walk(dbgSrv.Router, walkFn)
+		if err != nil {
+			// writer.WriteHeader(http.StatusInternalServerError)
+			// return
+			return nil, err
+		}
+
+		// writer.WriteHeader(http.StatusOK)
+		// _, _ = writer.Write(buf.Bytes())
+		// _ = request.Write(buf)
+		return buf, nil
+	})
+
 	dbgSrv.RegisterHandler(http.MethodGet, "/module/list.{format:(json|yaml|text)}", func(_ *http.Request) (interface{}, error) {
 		mods := op.ModuleManager.GetEnabledModuleNames()
 		sort.Strings(mods)


### PR DESCRIPTION
## Description

Added an endpoint  "/discovery" for the "/global/*" and "/module/*" routes. 
```
$curl http://localhost:9652/discovery

GET /global/config.{format:(json|yaml)}
GET /global/list.{format:(json|yaml)}
GET /global/patches.{format:(json|yaml)}
GET /global/snapshots.{format:(json|yaml)}
GET /global/values.{format:(json|yaml)}
GET /module/list.{format:(json|yaml|text)}
GET /module/resource-monitor.{format:(json|yaml)}
GET /module/{name}/patches.json
GET /module/{name}/render
GET /module/{name}/snapshots.{format:(json|yaml)}
GET /module/{name}/{type:(config|values)}.{format:(json|yaml)}
```

## Why do we need it, and what problem does it solve?

Fix https://github.com/deckhouse/deckhouse/issues/5827

## What is the expected result?

A new endpoint is available. Calling the endpoint returns a list of available routes "/global/*" and "/module/*".