### PR TITLE
[addon-operator] add module reregister

### DIFF
--- a/pkg/addon-operator/bootstrap.go
+++ b/pkg/addon-operator/bootstrap.go
@@ -87,6 +87,7 @@ func (op *AddonOperator) SetupModuleManager(modulesDir string, globalHooksDir st
 		HelmResourcesManager: op.HelmResourcesManager,
 		MetricStorage:        op.engine.MetricStorage,
 		HookMetricStorage:    op.engine.HookMetricStorage,
+		TaskQueues:           op.engine.TaskQueues,
 	}
 
 	cfg := module_manager.ModuleManagerConfig{

--- a/pkg/kube_config_manager/backend/backend.go
+++ b/pkg/kube_config_manager/backend/backend.go
@@ -13,7 +13,7 @@ type ConfigHandler interface {
 	StartInformer(ctx context.Context, eventC chan config.Event)
 
 	// LoadConfig loads initial modules config before starting the informer
-	LoadConfig(ctx context.Context) (*config.KubeConfig, error)
+	LoadConfig(ctx context.Context, modulesNames ...string) (*config.KubeConfig, error)
 
 	// SaveConfigValues saves patches for modules in backend (if supported), overriding the configuration
 	// Deprecated: saving values in the values source is not recommended and shouldn't be used anymore

--- a/pkg/kube_config_manager/backend/configmap/configmap.go
+++ b/pkg/kube_config_manager/backend/configmap/configmap.go
@@ -46,9 +46,9 @@ func New(logger dlogger.Logger, kubeClient *client.Client, namespace, name strin
 	return backend
 }
 
-// LoadConfig gets config from ConfigMap before starting informer.
+// LoadConfig gets config from ConfigMap before starting informer (selective loading configs for a list of modules isn't implemented).
 // Set checksums for global section and modules.
-func (b Backend) LoadConfig(ctx context.Context) (*config.KubeConfig, error) {
+func (b Backend) LoadConfig(ctx context.Context, _ ...string) (*config.KubeConfig, error) {
 	obj, err := b.getConfigMap(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/kube_config_manager/kube_config_manager.go
+++ b/pkg/kube_config_manager/kube_config_manager.go
@@ -78,7 +78,7 @@ func (kcm *KubeConfigManager) IsModuleEnabled(moduleName string) bool {
 		return false
 	}
 
-	return *moduleConfig.IsEnabled
+	return moduleConfig.IsEnabled != nil && *moduleConfig.IsEnabled
 }
 
 func (kcm *KubeConfigManager) Init() error {
@@ -119,12 +119,12 @@ func (kcm *KubeConfigManager) KubeConfigEventCh() chan config.KubeConfigEvent {
 
 // UpdateModuleConfig updates a single module config
 func (kcm *KubeConfigManager) UpdateModuleConfig(moduleName string) error {
-	newConfig, err := kcm.backend.LoadConfig(kcm.ctx)
+	newModuleConfig, err := kcm.backend.LoadConfig(kcm.ctx, moduleName)
 	if err != nil {
 		return err
 	}
 
-	if moduleConfig, found := newConfig.Modules[moduleName]; found {
+	if moduleConfig, found := newModuleConfig.Modules[moduleName]; found {
 		if kcm.knownChecksums != nil {
 			kcm.knownChecksums.Set(moduleName, moduleConfig.Checksum)
 		}

--- a/pkg/kube_config_manager/kube_config_manager.go
+++ b/pkg/kube_config_manager/kube_config_manager.go
@@ -117,6 +117,24 @@ func (kcm *KubeConfigManager) KubeConfigEventCh() chan config.KubeConfigEvent {
 	return kcm.configEventCh
 }
 
+// UpdateModuleConfig updates a single module config
+func (kcm *KubeConfigManager) UpdateModuleConfig(moduleName string) error {
+	newConfig, err := kcm.backend.LoadConfig(kcm.ctx)
+	if err != nil {
+		return err
+	}
+
+	if moduleConfig, found := newConfig.Modules[moduleName]; found {
+		if kcm.knownChecksums != nil {
+			kcm.knownChecksums.Set(moduleName, moduleConfig.Checksum)
+		}
+
+		kcm.currentConfig.Modules[moduleName] = moduleConfig
+	}
+
+	return nil
+}
+
 // loadConfig gets config from ConfigMap before starting informer.
 // Set checksums for global section and modules.
 func (kcm *KubeConfigManager) loadConfig() error {

--- a/pkg/kube_config_manager/kube_config_manager.go
+++ b/pkg/kube_config_manager/kube_config_manager.go
@@ -72,6 +72,15 @@ func NewKubeConfigManager(ctx context.Context, bk backend.ConfigHandler, runtime
 	}
 }
 
+func (kcm *KubeConfigManager) IsModuleEnabled(moduleName string) bool {
+	moduleConfig, found := kcm.currentConfig.Modules[moduleName]
+	if !found {
+		return false
+	}
+
+	return *moduleConfig.IsEnabled
+}
+
 func (kcm *KubeConfigManager) Init() error {
 	kcm.logEntry.Debug("Init: KubeConfigManager")
 

--- a/pkg/module_manager/loader/fs/fs.go
+++ b/pkg/module_manager/loader/fs/fs.go
@@ -77,7 +77,7 @@ func (fl *FileSystemLoader) getBasicModule(definition moduleDefinition, commonSt
 }
 
 // read single directory and return BasicModule for loading
-func (fl *FileSystemLoader) ReloadModule(moduleName, modulePath string) (*modules.BasicModule, error) {
+func (fl *FileSystemLoader) ReloadModule(_, modulePath string) (*modules.BasicModule, error) {
 	_, err := readDir(modulePath)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func (fl *FileSystemLoader) ReloadModule(moduleName, modulePath string) (*module
 		return nil, err
 	}
 
-	modDef, err := moduleFromDirName(moduleName, modulePath)
+	modDef, err := moduleFromDirName(filepath.Base(modulePath), modulePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/module_manager/loader/fs/fs.go
+++ b/pkg/module_manager/loader/fs/fs.go
@@ -29,6 +29,78 @@ func NewFileSystemLoader(moduleDirs string, vv *validation.ValuesValidator) *Fil
 	}
 }
 
+func (fl *FileSystemLoader) getBasicModule(definition moduleDefinition, commonStaticValues utils.Values) (*modules.BasicModule, error) {
+	err := validateModuleName(definition.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	valuesModuleName := utils.ModuleNameToValuesKey(definition.Name)
+	initialValues := utils.Values{valuesModuleName: map[string]interface{}{}}
+	// build initial values
+	// 1. from common static values
+	if commonStaticValues.HasKey(valuesModuleName) {
+		initialValues = utils.MergeValues(initialValues, commonStaticValues)
+	}
+
+	// 2. from module static values
+	moduleStaticValues, err := utils.LoadValuesFileFromDir(definition.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	if moduleStaticValues != nil {
+		initialValues = utils.MergeValues(initialValues, moduleStaticValues)
+	}
+
+	// 3. from openapi defaults
+
+	cb, vb, err := fl.readOpenAPIFiles(filepath.Join(definition.Path, "openapi"))
+	if err != nil {
+		return nil, err
+	}
+
+	if cb != nil && vb != nil {
+		err = fl.valuesValidator.SchemaStorage.AddModuleValuesSchemas(valuesModuleName, cb, vb)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	//
+	moduleValues, ok := initialValues[valuesModuleName].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expect map[string]interface{} in module values")
+	}
+
+	return modules.NewBasicModule(definition.Name, definition.Path, definition.Order, moduleValues, fl.valuesValidator), nil
+}
+
+// read single directory and return BasicModule for loading
+func (fl *FileSystemLoader) ReloadModule(moduleName, modulePath string) (*modules.BasicModule, error) {
+	_, err := readDir(modulePath)
+	if err != nil {
+		return nil, err
+	}
+
+	commonStaticValues, err := utils.LoadValuesFileFromDir(modulePath)
+	if err != nil {
+		return nil, err
+	}
+
+	modDef, err := moduleFromDirName(moduleName, modulePath)
+	if err != nil {
+		return nil, err
+	}
+
+	bm, err := fl.getBasicModule(modDef, commonStaticValues)
+	if err != nil {
+		return nil, err
+	}
+
+	return bm, nil
+}
+
 func (fl *FileSystemLoader) LoadModules() ([]*modules.BasicModule, error) {
 	result := make([]*modules.BasicModule, 0)
 
@@ -44,51 +116,10 @@ func (fl *FileSystemLoader) LoadModules() ([]*modules.BasicModule, error) {
 		}
 
 		for _, module := range modDefs {
-			err = validateModuleName(module.Name)
+			bm, err := fl.getBasicModule(module, commonStaticValues)
 			if err != nil {
 				return nil, err
 			}
-
-			valuesModuleName := utils.ModuleNameToValuesKey(module.Name)
-			initialValues := utils.Values{valuesModuleName: map[string]interface{}{}}
-			// build initial values
-			// 1. from common static values
-			if commonStaticValues.HasKey(valuesModuleName) {
-				initialValues = utils.MergeValues(initialValues, commonStaticValues)
-			}
-
-			// 2. from module static values
-			moduleStaticValues, err := utils.LoadValuesFileFromDir(module.Path)
-			if err != nil {
-				return nil, err
-			}
-
-			if moduleStaticValues != nil {
-				initialValues = utils.MergeValues(initialValues, moduleStaticValues)
-			}
-
-			// 3. from openapi defaults
-
-			cb, vb, err := fl.readOpenAPIFiles(filepath.Join(module.Path, "openapi"))
-			if err != nil {
-				return nil, err
-			}
-
-			if cb != nil && vb != nil {
-				err = fl.valuesValidator.SchemaStorage.AddModuleValuesSchemas(valuesModuleName, cb, vb)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			//
-			moduleValues, ok := initialValues[valuesModuleName].(map[string]interface{})
-			if !ok {
-				return nil, fmt.Errorf("expect map[string]interface{} in module values")
-			}
-
-			bm := modules.NewBasicModule(module.Name, module.Path, module.Order, moduleValues, fl.valuesValidator)
-
 			result = append(result, bm)
 		}
 	}
@@ -102,13 +133,23 @@ type moduleDefinition struct {
 	Order uint32
 }
 
-func (fl *FileSystemLoader) findModulesInDir(modulesDir string) ([]moduleDefinition, error) {
+// checks if dir exists and returns entries
+func readDir(modulesDir string) ([]os.DirEntry, error) {
 	dirEntries, err := os.ReadDir(modulesDir)
 	if err != nil && os.IsNotExist(err) {
 		return nil, fmt.Errorf("path '%s' does not exist", modulesDir)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("listing modules directory '%s': %s", modulesDir, err)
+	}
+
+	return dirEntries, nil
+}
+
+func (fl *FileSystemLoader) findModulesInDir(modulesDir string) ([]moduleDefinition, error) {
+	dirEntries, err := readDir(modulesDir)
+	if err != nil {
+		return nil, err
 	}
 
 	mods := make([]moduleDefinition, 0)

--- a/pkg/module_manager/loader/loader.go
+++ b/pkg/module_manager/loader/loader.go
@@ -6,4 +6,5 @@ import (
 
 type ModuleLoader interface {
 	LoadModules() ([]*modules.BasicModule, error)
+	ReloadModule(moduleName string, modulePath string) (*modules.BasicModule, error)
 }

--- a/pkg/module_manager/models/modules/events/events.go
+++ b/pkg/module_manager/models/modules/events/events.go
@@ -15,4 +15,7 @@ const (
 type ModuleEvent struct {
 	ModuleName string
 	EventType  ModuleEventType
+
+	// an option for registering a module without reload
+	Reregister bool
 }

--- a/pkg/module_manager/models/moduleset/moduleset_test.go
+++ b/pkg/module_manager/models/moduleset/moduleset_test.go
@@ -37,6 +37,7 @@ func TestBasicModuleSet(t *testing.T) {
 		Name:  "BasicModule-four",
 		Order: 20,
 	})
+	ms.SetInited()
 
 	expectNames := []string{
 		"BasicModule-one",
@@ -49,4 +50,5 @@ func TestBasicModuleSet(t *testing.T) {
 	g.Expect(ms.NamesInOrder()).Should(Equal(expectNames))
 	g.Expect(ms.Has("BasicModule-four")).Should(BeTrue(), "should have BasicModule-four")
 	g.Expect(ms.Get("BasicModule-four").Order).Should(Equal(uint32(20)), "should have BasicModule-four with order:20")
+	g.Expect(ms.IsInited()).Should(BeTrue(), "should be inited")
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
Changes:
A lot of changes related to starting/restarting/disabling a module without restarting addon-operator.
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
With this PR we can provide a way of reloading (restarting its life cycle like disabling and deregistering its hooks, reloading its configuration and re-run the module)  a single module without restarting addon-operator.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
