### PR TITLE
validate all enabled modules

### DIFF
--- a/pkg/kube_config_manager/config/event.go
+++ b/pkg/kube_config_manager/config/event.go
@@ -1,5 +1,13 @@
 package config
 
+type Op string
+
+const (
+	EventDelete Op = "Delete"
+	EventUpdate Op = "Update"
+	EventAdd    Op = "Add"
+)
+
 type Event struct {
 	// Key possible values
 	// "" - reset the whole config
@@ -9,4 +17,5 @@ type Event struct {
 	Key    string
 	Config *KubeConfig
 	Err    error
+	Op     Op
 }

--- a/pkg/module_manager/models/modules/values_layered.go
+++ b/pkg/module_manager/models/modules/values_layered.go
@@ -25,6 +25,8 @@ func mergeLayers(initial utils.Values, layers ...interface{}) utils.Values {
 			res = utils.MergeValues(res, layer(res))
 		case valuesTransformer:
 			res = utils.MergeValues(res, layer.Transform(res))
+		case nil:
+			continue
 		}
 	}
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -316,7 +316,7 @@ func (mm *ModuleManager) validateNewKubeConfig(kubeConfig *config.KubeConfig, al
 		// Check if enabledModules are valid
 		// if module is enabled, we have to check config is valid
 		// otherwise we have to just save the config, because we can have some absent defaults or something like that
-		if _, has := allModules[moduleName]; has && moduleConfig.GetEnabled() != "false" {
+		if _, moduleExists := allModules[moduleName]; moduleExists && (moduleConfig.GetEnabled() == "true" || mm.IsModuleEnabled(moduleName)) {
 			validateConfig = true
 		}
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -316,21 +316,19 @@ func (mm *ModuleManager) validateNewKubeConfig(kubeConfig *config.KubeConfig, al
 		// Check if enabledModules are valid
 		// if module is enabled, we have to check config is valid
 		// otherwise we have to just save the config, because we can have some absent defaults or something like that
-		if _, has := allModules[moduleName]; has && mm.IsModuleEnabled(moduleName) {
+		if _, has := allModules[moduleName]; has && moduleConfig.GetEnabled() != "false" {
 			validateConfig = true
 		}
 
-		if validateConfig {
-			// if module config values are empty - return empty values (without static and openapi default values)
-			if len(moduleConfig.GetValues()) == 0 {
-				valuesMap[mod.GetName()] = utils.Values{}
-			} else {
-				newValues, validationErr := mod.GenerateNewConfigValues(moduleConfig.GetValues(), true)
-				if validationErr != nil {
-					_ = multierror.Append(validationErrors, validationErr)
-				}
-				valuesMap[mod.GetName()] = newValues
+		// if module config values are empty - return empty values (without static and openapi default values)
+		if len(moduleConfig.GetValues()) == 0 {
+			valuesMap[mod.GetName()] = utils.Values{}
+		} else {
+			newValues, validationErr := mod.GenerateNewConfigValues(moduleConfig.GetValues(), validateConfig)
+			if validationErr != nil {
+				_ = multierror.Append(validationErrors, validationErr)
 			}
+			valuesMap[mod.GetName()] = newValues
 		}
 	}
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -290,7 +290,7 @@ func (mm *ModuleManager) HandleNewKubeConfig(kubeConfig *config.KubeConfig) (*Mo
 	return nil, nil
 }
 
-func (mm *ModuleManager) validateNewKubeConfig(kubeConfig *config.KubeConfig, newEnabledByConfig map[string]struct{}) (map[string]utils.Values, error) {
+func (mm *ModuleManager) validateNewKubeConfig(kubeConfig *config.KubeConfig, allModules map[string]struct{}) (map[string]utils.Values, error) {
 	validationErrors := &multierror.Error{}
 
 	valuesMap := make(map[string]utils.Values)
@@ -316,7 +316,7 @@ func (mm *ModuleManager) validateNewKubeConfig(kubeConfig *config.KubeConfig, ne
 		// Check if enabledModules are valid
 		// if module is enabled, we have to check config is valid
 		// otherwise we have to just save the config, because we can have some absent defaults or something like that
-		if _, has := newEnabledByConfig[moduleName]; has {
+		if _, has := allModules[moduleName]; has && mm.IsModuleEnabled(moduleName) {
 			validateConfig = true
 		}
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -217,7 +217,7 @@ func (mm *ModuleManager) HandleNewKubeConfig(kubeConfig *config.KubeConfig) (*Mo
 
 	// Get map of enabled modules after KubeConfig changes.
 	newEnabledByConfig := mm.calculateEnabledModulesByConfig(kubeConfig)
-	allModules := make(map[string]struct{})
+	allModules := make(map[string]struct{}, len(mm.modules.NamesInOrder()))
 	for _, module := range mm.modules.NamesInOrder() {
 		allModules[module] = struct{}{}
 	}

--- a/pkg/utils/module_config.go
+++ b/pkg/utils/module_config.go
@@ -94,6 +94,11 @@ func (mc *ModuleConfig) GetValues() Values {
 	return mc.values
 }
 
+// DropValues removes values from module config
+func (mc *ModuleConfig) DropValues() {
+	mc.values = Values{}
+}
+
 // LoadFromValues loads module config from a map.
 //
 // Values for module in `values` map are addressed by a key.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
<!-- Describe your changes briefly here. -->
This pr should fix the situation when dynamically enabled modules don't get their config values applied if `enabled: true` isn't set in their configuration. Also, there were several other problems to solve like: module configs for dynamically enabled modules aren't applied at startup.
Relates to https://github.com/deckhouse/deckhouse/pull/7036.

#### What this PR does / why we need it
There is a problem with dynamically enabled modules (that are launched by global hooks) not getting their kube config values applied  if `enabled: true` isn't set explicitly. It happens because HandleNewKubeConfig method doesn't count dynamically enabled modules as modules enabled by config which is partially true (enabled isn't set), but these modules still should have their config values applied and recalculated each time their configs change if `enabled: false` isn't set.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
