### PR TITLE
(question) Deploy apps in ther own namespaces

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -1266,7 +1266,13 @@ func (op *AddonOperator) HandleModulePurge(t sh_task.Task, labels map[string]str
 	logEntry.Debugf("Module purge start")
 
 	hm := task.HookMetadataAccessor(t)
-	err := op.Helm.NewClient(t.GetLogLabels()).DeleteRelease(hm.ModuleName)
+	baseModule := op.ModuleManager.GetModule(hm.ModuleName)
+	if baseModule == nil {
+		logEntry.Warnf("Module purge failed, module not found")
+		status = queue.Success
+		return
+	}
+	err := op.Helm.NewClient(baseModule.Namespace, t.GetLogLabels()).DeleteRelease(hm.ModuleName)
 	if err != nil {
 		// Purge is for unknown modules, just print warning.
 		logEntry.Warnf("Module purge failed, no retry. Error: %s", err)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -42,6 +42,10 @@ var (
 
 	// StrictModeEnabled fail with error if MODULES_DIR/values.yaml does not exist
 	StrictModeEnabled = false
+
+	// For discovery operator's resources
+	ManagedResourceLabelKey   = "addon-operator"
+	ManagedResourceLabelValue = "true"
 )
 
 const (

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -2,8 +2,9 @@ package helm
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm/client"
@@ -56,6 +57,7 @@ func (f *ClientFactory) NewClient(namespace string, logLabels ...map[string]stri
 			KubeClient: f.kubeClient,
 		}, logLabels...)
 		if err != nil {
+			//!!! TODO Remove os.Exit and return error
 			fmt.Printf("Error while init helm3: %s\n", err)
 			os.Exit(1)
 		}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -1,7 +1,9 @@
 package helm
 
 import (
+	"fmt"
 	log "github.com/sirupsen/logrus"
+	"os"
 
 	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm/client"
@@ -11,46 +13,65 @@ import (
 )
 
 type ClientFactory struct {
+	kubeClient  *klient.Client
+	cache       map[string]client.HelmClient
 	NewClientFn func(logLabels ...map[string]string) client.HelmClient
 }
 
-func (f *ClientFactory) NewClient(logLabels ...map[string]string) client.HelmClient {
+func (f *ClientFactory) NewClient(namespace string, logLabels ...map[string]string) client.HelmClient {
 	if f.NewClientFn != nil {
 		return f.NewClientFn(logLabels...)
 	}
-	return nil
-}
 
-func InitHelmClientFactory(kubeClient *klient.Client) (*ClientFactory, error) {
-	helmVersion, err := DetectHelmVersion()
-	if err != nil {
-		return nil, err
+	if client, ok := f.cache[namespace]; ok {
+		return client
 	}
 
-	factory := new(ClientFactory)
+	helmVersion, _ := DetectHelmVersion()
+
+	if namespace == "" {
+		namespace = app.Namespace
+	}
+
+	var client client.HelmClient
+	var err error
 
 	switch helmVersion {
 	case Helm3Lib:
 		log.Info("Helm3Lib detected. Use builtin Helm.")
-		factory.NewClientFn = helm3lib.NewClient
-		helm3lib.Init(&helm3lib.Options{
-			Namespace:  app.Namespace,
+		client = helm3lib.NewClient(&helm3lib.Options{
+			Namespace:  namespace,
 			HistoryMax: app.Helm3HistoryMax,
 			Timeout:    app.Helm3Timeout,
-			KubeClient: kubeClient,
-		})
+			KubeClient: f.kubeClient,
+		}, logLabels...)
 
 	case Helm3:
 		log.Infof("Helm 3 detected (path is '%s')", helm3.Helm3Path)
 		// Use helm3 client.
-		factory.NewClientFn = helm3.NewClient
-		err = helm3.Init(&helm3.Helm3Options{
-			Namespace:  app.Namespace,
+		client, err = helm3.NewClient(&helm3.Helm3Options{
+			Namespace:  namespace,
 			HistoryMax: app.Helm3HistoryMax,
 			Timeout:    app.Helm3Timeout,
-			KubeClient: kubeClient,
-		})
+			KubeClient: f.kubeClient,
+		}, logLabels...)
+		if err != nil {
+			fmt.Printf("Error while init helm3: %s\n", err)
+			os.Exit(1)
+		}
 	}
+	f.cache[namespace] = client
+	return client
+}
+
+func InitHelmClientFactory(kubeClient *klient.Client) (*ClientFactory, error) {
+	_, err := DetectHelmVersion()
+	if err != nil {
+		return nil, err
+	}
+	factory := new(ClientFactory)
+	factory.kubeClient = kubeClient
+	factory.cache = make(map[string]client.HelmClient)
 
 	if err != nil {
 		return nil, err

--- a/pkg/helm/helm3/helm3.go
+++ b/pkg/helm/helm3/helm3.go
@@ -31,11 +31,6 @@ type Helm3Options struct {
 	Timeout    time.Duration
 }
 
-// Init runs
-func Init(options *Helm3Options) error {
-	return nil
-}
-
 type Helm3Client struct {
 	Namespace  string
 	HistoryMax int32

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -62,7 +62,7 @@ func NewClient(options *Options, logLabels ...map[string]string) client.HelmClie
 	}
 
 	return &LibClient{
-		LogEntry:   options.LogEntry,
+		LogEntry:   logEntry,
 		KubeClient: options.KubeClient,
 		Namespace:  options.Namespace,
 		HistoryMax: options.HistoryMax,

--- a/pkg/helm/helm3lib/helm3lib_test.go
+++ b/pkg/helm/helm3lib/helm3lib_test.go
@@ -42,10 +42,32 @@ func TestHelm3LibUpgradeDelete(t *testing.T) {
 
 	err := cl.UpgradeRelease("test-release", "testdata/chart", nil, nil, cl.Namespace)
 	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// We can not create labels, see comments in markReleaseWithOperatorLabel
+
+	// namespaces, _ := cl.KubeClient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	// nsExists := false
+	// labelsExists := false
+	// for _, ns := range namespaces.Items {
+	// 	if ns.Name != "test-ns" {
+	// 		continue
+	// 	}
+	// 	nsExists = true
+	// 	labels := ns.GetLabels()
+	// 	t.Logf("Labels: %v", labels)
+	// 	value, ok := labels[app.ManagedResourceLabelKey]
+	// 	if ok && value == app.ManagedResourceLabelValue {
+	// 		labelsExists = true
+	// 	}
+	// 	break
+	// }
+	// g.Expect(nsExists).Should(BeTrue(), "namespace doesn't exists")
+	// g.Expect(labelsExists).Should(BeTrue(), "namespace should contain operator labels")
 }
 
 func initHelmClient(t *testing.T) *LibClient {
 	fCluster := fake.NewFakeCluster(fake.ClusterVersionV125)
+	fCluster.CreateNs("test-ns")
 
 	actionConfig = actionConfigFixture(t)
 

--- a/pkg/helm/helm3lib/helm3lib_test.go
+++ b/pkg/helm/helm3lib/helm3lib_test.go
@@ -47,19 +47,14 @@ func TestHelm3LibUpgradeDelete(t *testing.T) {
 func initHelmClient(t *testing.T) *LibClient {
 	fCluster := fake.NewFakeCluster(fake.ClusterVersionV125)
 
-	Init(&Options{
-		Namespace:  "test-ns",
-		HistoryMax: 10,
-		Timeout:    0,
-		KubeClient: fCluster.Client,
-	})
-
 	actionConfig = actionConfigFixture(t)
 
 	cl := &LibClient{
 		LogEntry:   log.NewEntry(log.StandardLogger()),
-		KubeClient: options.KubeClient,
-		Namespace:  options.Namespace,
+		KubeClient: fCluster.Client,
+		Namespace:  "test-ns",
+		HistoryMax: 10,
+		Timeout:    0,
 	}
 
 	return cl

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -27,7 +27,7 @@ func TestHelmFactory(t *testing.T) {
 		g.Expect(err).ShouldNot(HaveOccurred())
 
 		// Ensure client is a builtin Helm3 library.
-		helmCl := helm.NewClient(nil)
+		helmCl := helm.NewClient("default", nil)
 		g.Expect(helmCl).To(BeAssignableToTypeOf(new(helm3.Helm3Client)), "should create helm3ib client")
 	})
 
@@ -46,7 +46,7 @@ func TestHelmFactory(t *testing.T) {
 		g.Expect(err).ShouldNot(HaveOccurred())
 
 		// Ensure client is a builtin Helm3 library.
-		helmCl := helm.NewClient(nil)
+		helmCl := helm.NewClient("default", nil)
 		g.Expect(helmCl).To(BeAssignableToTypeOf(new(helm3lib.LibClient)), "should create helm3ib client")
 
 		// Do simple test against fake cluster.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Allows to install modules (or rather their charts) in their own namespaces.

#### What this PR does / why we need it

By default, all helm applications are installed in one namespace. To install in a different namespace, you must specify it in each chart resource. Therefore, you cannot use external charts (through a dependency in Chart.yaml) whose resources do not contain fields with namespace. This code allows you to create a 'namespace' file in each module, in which you can specify its name (as you can now do in deckhouse in .namespace files) and the addon-operator will install the module in the specified namespace.

#### Special notes for your reviewer

Most likely this is not production code, since it was made in a day, not tested in production, and I am more of a devops engineer than a programmer. This pull request is more about whether this is a problem and whether this behavior will ever be implemented.

I needed to redo the basic logic of working with helm3 and helm3lib in terms of client initialization. By default, there is only one client and its settings were specified through the global options variable. I removed this global variable, and also remade the ClientFactory so that each module has its own client for its namespace (in the cache field). I also added arguments to create a namespace when creating helm release.

So far the only problem is the lack of namespace removal after module removal.