### PR TITLE
add dedicated basic module status - hooks disabled

### DIFF
--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -837,6 +837,8 @@ const (
 	EnableScheduleBindings ModuleRunPhase = "EnableScheduleBindings"
 	// CanRunHelm - module is ready to run its Helm chart.
 	CanRunHelm ModuleRunPhase = "CanRunHelm"
+	// HooksDisabled - module has its hooks disabled (before update or deletion).
+	HooksDisabled ModuleRunPhase = "HooksDisabled"
 )
 
 type moduleState struct {

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -927,6 +927,8 @@ func (mm *ModuleManager) DisableModuleHooks(moduleName string) {
 	for _, mh := range schHooks {
 		mh.GetHookController().DisableScheduleBindings()
 	}
+
+	ml.SetPhase(modules.HooksDisabled)
 }
 
 func (mm *ModuleManager) HandleScheduleEvent(crontab string, createGlobalTaskFn func(*hooks.GlobalHook, controller.BindingExecutionInfo), createModuleTaskFn func(*modules.BasicModule, *hooks.ModuleHook, controller.BindingExecutionInfo)) error {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
This pr introduces an additional module state: `HooksDisabled`. In some situations it makes sense to disable a module hooks (mostly before deleting or when updating the module) and this state would allow reflecting the module status appropriately. 
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
Thir pr adds an additional module state `HooksDisabled` and updates a module state accordingly when the moduleManager's `DisableModuleHooks` method is invocated.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
