### PR TITLE
Send events at module state change

### DIFF
--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -466,6 +466,7 @@ func (bm *BasicModule) RunEnabledScript(tmpDir string, precedingEnabledModules [
 		result = "Enabled"
 	}
 	logEntry.Infof("Enabled script run successful, result '%v', module '%s'", moduleEnabled, result)
+	bm.state.enabledScriptResult = &moduleEnabled
 	return moduleEnabled, nil
 }
 
@@ -828,6 +829,11 @@ func (bm *BasicModule) GetHookErrorsSummary() string {
 	return strings.Join(hooksState, "\n")
 }
 
+// GetEnabledScriptResult returns a bool pointer to the enabled script results
+func (bm *BasicModule) GetEnabledScriptResult() *bool {
+	return bm.state.enabledScriptResult
+}
+
 // GetLastHookError get error of the last executed hook
 func (bm *BasicModule) GetLastHookError() error {
 	bm.state.hookErrorsLock.RLock()
@@ -872,4 +878,5 @@ type moduleState struct {
 	hookErrors           map[string]error
 	hookErrorsLock       sync.RWMutex
 	synchronizationState *SynchronizationState
+	enabledScriptResult  *bool
 }

--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -273,11 +273,6 @@ func (bm *BasicModule) SaveHookError(hookName string, err error) {
 	bm.state.hookErrorsLock.Lock()
 	defer bm.state.hookErrorsLock.Unlock()
 
-	if err == nil {
-		delete(bm.state.hookErrors, hookName)
-		return
-	}
-
 	bm.state.hookErrors[hookName] = err
 }
 
@@ -812,6 +807,25 @@ func (bm *BasicModule) GetHookByName(name string) *hooks.ModuleHook {
 // GetValuesPatches returns patches for debug output
 func (bm *BasicModule) GetValuesPatches() []utils.ValuesPatch {
 	return bm.valuesStorage.getValuesPatches()
+}
+
+// GetHookErrorsSummary get hooks errors summary report
+func (bm *BasicModule) GetHookErrorsSummary() string {
+	bm.state.hookErrorsLock.RLock()
+	defer bm.state.hookErrorsLock.RUnlock()
+
+	hooksState := make([]string, 0, len(bm.state.hookErrors))
+	for name, err := range bm.state.hookErrors {
+		errorMsg := fmt.Sprint(err)
+		if err == nil {
+			errorMsg = "ok"
+		}
+
+		hooksState = append(hooksState, fmt.Sprintf("%s: %s", name, errorMsg))
+	}
+
+	sort.Strings(hooksState)
+	return strings.Join(hooksState, "\n")
 }
 
 // GetLastHookError get error of the last executed hook

--- a/pkg/module_manager/models/modules/events/events.go
+++ b/pkg/module_manager/models/modules/events/events.go
@@ -7,6 +7,8 @@ const (
 	ModuleRegistered ModuleEventType = iota
 	ModuleEnabled
 	ModuleDisabled
+	ModuleStateChanged
+	ModuleConfigChanged
 
 	FirstConvergeDone
 )


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
Following changes:
- Two new module events were added: ModuleStateChanged and ModuleConfig changed;
- Modules got a new state field enabledScriptResults that contains the result of running the enabled script of a module. It comes in handy when we need to know if a module was disabled by its script or something else;
- Modules can "export" their hooks' statuses via a new method;
- Module manager got several new methods which can be used to alter a module and send a relevant event over a notification channel (like setting a module last error and updating hooks' statuses);
-  Module manager can be set to use a pre-created notification channel.
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
This PR provides some additional calls that can be used to provide a better view of what and when is happening to modules of the operator.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
