### PR TITLE
fix camelCase to kebab-case conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2
+	github.com/ettle/strcase v0.2.0
 	github.com/flant/kube-client v1.1.0
 	github.com/flant/shell-operator v1.4.4
 	github.com/go-chi/chi/v5 v5.0.10

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKf
 github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
+github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -72,7 +72,6 @@ type AddonOperator struct {
 	// AdmissionServer handles validation and mutation admission webhooks
 	AdmissionServer *AdmissionServer
 
-
 	MetricStorage *metric_storage.MetricStorage
 
 	// LeaderElector represents leaderelection client for HA mode

--- a/pkg/kube_config_manager/kube_config_manager_test.go
+++ b/pkg/kube_config_manager/kube_config_manager_test.go
@@ -319,7 +319,7 @@ param2: val2
 
 	kcm.SafeReadConfig(func(config *config.KubeConfig) {
 		g.Expect(config.Modules).To(HaveLen(1), "Module section should appear after ConfigMap update")
-		g.Expect(config.Modules).To(HaveKey("module-2"), "module-2 section should appear after ConfigMap update")
+		g.Expect(config.Modules).To(HaveKey("module2"), "module2 section should appear after ConfigMap update")
 	})
 
 	// Update ConfigMap with global section.

--- a/pkg/utils/values.go
+++ b/pkg/utils/values.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/segmentio/go-camelcase"
+	"github.com/ettle/strcase"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	k8syaml "sigs.k8s.io/yaml"
@@ -23,38 +23,12 @@ type Values map[string]interface{}
 
 // ModuleNameToValuesKey returns camelCased name from kebab-cased (very-simple-module become verySimpleModule)
 func ModuleNameToValuesKey(moduleName string) string {
-	return camelcase.Camelcase(moduleName)
+	return strcase.ToCamel(moduleName)
 }
 
-// ModuleNameFromValuesKey returns kebab-cased name from camelCased (verySimpleModule become ver-simple-module)
+// ModuleNameFromValuesKey returns kebab-cased name from camelCased (verySimpleModule become very-simple-module)
 func ModuleNameFromValuesKey(moduleValuesKey string) string {
-	b := make([]byte, 0, 64)
-	l := len(moduleValuesKey)
-	i := 0
-
-	for i < l {
-		c := moduleValuesKey[i]
-		switch {
-		case c >= 'A' && c <= 'Z':
-			if i > 0 {
-				// Appends dash module name parts delimiter.
-				b = append(b, '-')
-			}
-			// Appends lowercased symbol.
-			b = append(b, c+('a'-'A'))
-		case c >= '0' && c <= '9':
-			if i > 0 {
-				// Appends dash module name parts delimiter.
-				b = append(b, '-')
-			}
-			b = append(b, c)
-		default:
-			b = append(b, c)
-		}
-		i++
-	}
-
-	return string(b)
+	return strcase.ToKebab(moduleValuesKey)
 }
 
 // NewValuesFromBytes loads values sections from maps in yaml or json format

--- a/pkg/utils/values_test.go
+++ b/pkg/utils/values_test.go
@@ -58,11 +58,13 @@ func Test_ModuleName_Conversions(t *testing.T) {
 	var err error
 
 	for _, strs := range [][]string{
-		{"module-1", "module1"},
+		{"module1", "module1"},
 		{"prometheus", "prometheus"},
 		{"prometheus-operator", "prometheusOperator"},
 		{"hello-world-module", "helloWorldModule"},
 		{"cert-manager-crd", "certManagerCrd"},
+		{"l2-load-balancer", "l2LoadBalancer"},
+		{"2-module-name", "2ModuleName"},
 	} {
 		moduleName := strs[0]
 		moduleValuesKey := strs[1]
@@ -200,9 +202,9 @@ func TestNameValuesKeyNameConsistence(t *testing.T) {
 			"module-one",
 		},
 		{
-			"module-one-0-1",
+			"module-one01",
 			"moduleOne01",
-			"module-one-0-1",
+			"module-one01",
 		},
 		{
 			// Inconsistent module name!


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
The camelCase to kebab-case string conversion function is updated to use "github.com/ettle/strcase" package instead of local implementation. It should allow converting module names containing digits more correctly.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
It updates the way we convert camelCased strings to kebab-cased. At now, if we have something like 'l2-load-balancer' in kebab-case, after converting to camelCase and back it ends up with 'l-2-load-balancer'.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
