### PR TITLE
Refactor list logic for helm3 and helm3lib

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -130,7 +130,7 @@ func (op *AddonOperator) WithLeaderElector(config *leaderelection.LeaderElection
 
 func (op *AddonOperator) Setup() error {
 	// Helm client factory.
-	helmClient, err := helm.InitHelmClientFactory(op.engine.KubeClient)
+	helmClient, err := helm.InitHelmClientFactory()
 	if err != nil {
 		return fmt.Errorf("initialize Helm: %s", err)
 	}

--- a/pkg/helm/client/client.go
+++ b/pkg/helm/client/client.go
@@ -8,6 +8,6 @@ type HelmClient interface {
 	Render(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string, debug bool) (string, error)
 	GetReleaseValues(releaseName string) (utils.Values, error)
 	DeleteRelease(releaseName string) error
-	ListReleasesNames(labelSelector map[string]string) ([]string, error)
+	ListReleasesNames() ([]string, error)
 	IsReleaseExists(releaseName string) (bool, error)
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/helm/helm3"
 	"github.com/flant/addon-operator/pkg/helm/helm3lib"
-	klient "github.com/flant/kube-client/client"
 )
 
 type ClientFactory struct {
@@ -21,7 +20,7 @@ func (f *ClientFactory) NewClient(logLabels ...map[string]string) client.HelmCli
 	return nil
 }
 
-func InitHelmClientFactory(kubeClient *klient.Client) (*ClientFactory, error) {
+func InitHelmClientFactory() (*ClientFactory, error) {
 	helmVersion, err := DetectHelmVersion()
 	if err != nil {
 		return nil, err
@@ -33,11 +32,10 @@ func InitHelmClientFactory(kubeClient *klient.Client) (*ClientFactory, error) {
 	case Helm3Lib:
 		log.Info("Helm3Lib detected. Use builtin Helm.")
 		factory.NewClientFn = helm3lib.NewClient
-		helm3lib.Init(&helm3lib.Options{
+		err = helm3lib.Init(&helm3lib.Options{
 			Namespace:  app.Namespace,
 			HistoryMax: app.Helm3HistoryMax,
 			Timeout:    app.Helm3Timeout,
-			KubeClient: kubeClient,
 		})
 
 	case Helm3:
@@ -48,7 +46,6 @@ func InitHelmClientFactory(kubeClient *klient.Client) (*ClientFactory, error) {
 			Namespace:  app.Namespace,
 			HistoryMax: app.Helm3HistoryMax,
 			Timeout:    app.Helm3Timeout,
-			KubeClient: kubeClient,
 		})
 	}
 

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -6,54 +6,74 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm/helm3"
 	"github.com/flant/addon-operator/pkg/helm/helm3lib"
-	klient "github.com/flant/kube-client/client"
 )
 
 func TestHelmFactory(t *testing.T) {
-	t.Run("init with helm3 binary client", func(t *testing.T) {
+	testCLient := func(t *testing.T, name string, clientType interface{}, envsToSet map[string]string) {
 		g := NewWithT(t)
 
-		// Explicitly set path to the Helm3 binary.
-		_ = os.Setenv("HELM_BIN_PATH", "testdata/helm-fake/helm3/helm")
-		defer os.Unsetenv("HELM_BIN_PATH")
+		for env, value := range envsToSet {
+			os.Setenv(env, value)
+			defer os.Unsetenv(env)
+		}
 
-		// Setup fake client.
-		kubeClient := klient.NewFake(nil)
-
+		// For integration tests, but should be set before init
+		app.Namespace = os.Getenv("ADDON_OPERATOR_NAMESPACE")
 		// Setup Helm client factory.
-		helm, err := InitHelmClientFactory(kubeClient)
+		helm, err := InitHelmClientFactory()
 		g.Expect(err).ShouldNot(HaveOccurred())
 
 		// Ensure client is a builtin Helm3 library.
 		helmCl := helm.NewClient(nil)
-		g.Expect(helmCl).To(BeAssignableToTypeOf(new(helm3.Helm3Client)), "should create helm3ib client")
+		g.Expect(helmCl).To(BeAssignableToTypeOf(clientType), "should create %s client", name)
+
+		if os.Getenv("ADDON_OPERATOR_HELM_INTEGRATION_TEST") != "yes" {
+			t.Skip("Do not run this on CI")
+		}
+
+		releases, err := helmCl.ListReleasesNames()
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(releases).To(BeComparableTo([]string{}), "should get empty list of releases")
+
+		_, _, err = helmCl.LastReleaseStatus("test-release")
+		g.Expect(err).Should(HaveOccurred(), "should fail getting release status in the empty cluster")
+
+		isExists, err := helmCl.IsReleaseExists("test-release")
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(isExists).Should(BeFalse(), "should not found release in the empty cluster")
+
+		err = helmCl.UpgradeRelease("test-release", "helm3lib/testdata/chart", nil, nil, app.Namespace)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		releasesAfterUpgrade, err := helmCl.ListReleasesNames()
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(releasesAfterUpgrade).To(BeComparableTo([]string{"test-release"}), "should get list of releases")
+
+		revision, status, err := helmCl.LastReleaseStatus("test-release")
+		g.Expect(err).ShouldNot(HaveOccurred(), "should get release status in the cluster")
+		g.Expect(status).To(Equal("deployed"), "status of the release should be deployed")
+		g.Expect(revision).To(Equal("1"), "revision of the release should be 1")
+
+		isExistsAfterUpgrade, err := helmCl.IsReleaseExists("test-release")
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(isExistsAfterUpgrade).Should(BeTrue(), "should found the release in the cluster")
+
+		err = helmCl.DeleteRelease("test-release")
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		isExistsAfterDelete, err := helmCl.IsReleaseExists("test-release")
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(isExistsAfterDelete).Should(BeFalse(), "should not found the release in the cluster")
+	}
+
+	t.Run("init with helm3 binary client", func(t *testing.T) {
+		testCLient(t, "helm3lib", new(helm3.Helm3Client), map[string]string{"HELM_BIN_PATH": "/opt/homebrew/bin/helm"})
 	})
 
 	t.Run("init with helm3lib client", func(t *testing.T) {
-		g := NewWithT(t)
-
-		// Explicitly use builtin Helm client.
-		_ = os.Setenv("HELM3LIB", "yes")
-		defer os.Unsetenv("HELM3LIB")
-
-		// Setup fake client.
-		kubeClient := klient.NewFake(nil)
-
-		// Setup Helm client factory.
-		helm, err := InitHelmClientFactory(kubeClient)
-		g.Expect(err).ShouldNot(HaveOccurred())
-
-		// Ensure client is a builtin Helm3 library.
-		helmCl := helm.NewClient(nil)
-		g.Expect(helmCl).To(BeAssignableToTypeOf(new(helm3lib.LibClient)), "should create helm3ib client")
-
-		// Do simple test against fake cluster.
-		var releases []string
-
-		releases, err = helmCl.ListReleasesNames(nil)
-		g.Expect(err).ShouldNot(HaveOccurred())
-		g.Expect(releases).To(BeComparableTo([]string{}), "should get empty list of releases")
+		testCLient(t, "helm3", new(helm3lib.LibClient), map[string]string{"HELM3LIB": "yes"})
 	})
 }

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -70,7 +70,8 @@ func TestHelmFactory(t *testing.T) {
 	}
 
 	t.Run("init with helm3 binary client", func(t *testing.T) {
-		testCLient(t, "helm3lib", new(helm3.Helm3Client), map[string]string{"HELM_BIN_PATH": "/opt/homebrew/bin/helm"})
+		// For integration tests set appropriate helm binary path
+		testCLient(t, "helm3lib", new(helm3.Helm3Client), map[string]string{"HELM_BIN_PATH": "testdata/helm-fake/helm3/helm"})
 	})
 
 	t.Run("init with helm3lib client", func(t *testing.T) {

--- a/pkg/helm/test/mock/mock.go
+++ b/pkg/helm/test/mock/mock.go
@@ -23,7 +23,7 @@ type Client struct {
 
 var _ client.HelmClient = &Client{}
 
-func (c *Client) ListReleasesNames(_ map[string]string) ([]string, error) {
+func (c *Client) ListReleasesNames() ([]string, error) {
 	if c.ReleaseNames != nil {
 		return c.ReleaseNames, nil
 	}

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -532,7 +532,7 @@ func (mm *ModuleManager) RefreshStateFromHelmReleases(logLabels map[string]strin
 	if mm.dependencies.Helm == nil {
 		return &ModulesState{}, nil
 	}
-	releasedModules, err := mm.dependencies.Helm.NewClient(logLabels).ListReleasesNames(nil)
+	releasedModules, err := mm.dependencies.Helm.NewClient(logLabels).ListReleasesNames()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

Make helm3/helm3lib list logic use "native" tools
 
#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
* Use cmd `helm` to list releases in helm3
* Use `action.NewList` to list releases in helm3lib
* Add support for [default](https://github.com/helm/helm/blob/v3.10.3/cmd/helm/root.go#L54) `HELM_DRIVER` env
* Minor refactor of helm3 cmd args making
* Remove unused arg in `ListReleasesNames` func

#### Special notes for your reviewer
Support for `HELM_DRIVER` env is necessary when deploying addon-operator to the same namespace with other apps (in namespace as a service envs, for example).
Setting different `HELM_DRIVER` in addon-operator will prevent deleting releases of other apps (non-modules). 