### PR TITLE
Draft: feat: Added support for targetnamespaces

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -3,6 +3,7 @@ package addon_operator
 import (
 	"context"
 	"fmt"
+	"github.com/flant/shell-operator/pkg/debug"
 	"path"
 	"runtime/trace"
 	"strings"
@@ -30,7 +31,6 @@ import (
 	"github.com/flant/kube-client/client"
 	sh_app "github.com/flant/shell-operator/pkg/app"
 	runtimeConfig "github.com/flant/shell-operator/pkg/config"
-	"github.com/flant/shell-operator/pkg/debug"
 	bc "github.com/flant/shell-operator/pkg/hook/binding_context"
 	"github.com/flant/shell-operator/pkg/hook/controller"
 	htypes "github.com/flant/shell-operator/pkg/hook/types"
@@ -1291,7 +1291,8 @@ func (op *AddonOperator) HandleModulePurge(t sh_task.Task, labels map[string]str
 	logEntry.Debugf("Module purge start")
 
 	hm := task.HookMetadataAccessor(t)
-	err := op.Helm.NewClient(t.GetLogLabels()).DeleteRelease(hm.ModuleName)
+	namespace, _ := op.ModuleManager.GetModule(hm.ModuleName).GetDefaultOrDefinedNamespace()
+	err := op.Helm.NewClient(t.GetLogLabels()).DeleteRelease(namespace, hm.ModuleName)
 	if err != nil {
 		// Purge is for unknown modules, just print warning.
 		logEntry.Warnf("Module purge failed, no retry. Error: %s", err)

--- a/pkg/helm/client/client.go
+++ b/pkg/helm/client/client.go
@@ -3,11 +3,11 @@ package client
 import "github.com/flant/addon-operator/pkg/utils"
 
 type HelmClient interface {
-	LastReleaseStatus(releaseName string) (string, string, error)
+	LastReleaseStatus(releaseNamespace string, releaseName string) (string, string, error)
 	UpgradeRelease(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string) error
 	Render(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string, debug bool) (string, error)
-	GetReleaseValues(releaseName string) (utils.Values, error)
-	DeleteRelease(releaseName string) error
-	ListReleasesNames() ([]string, error)
-	IsReleaseExists(releaseName string) (bool, error)
+	GetReleaseValues(releaseNamespace string, releaseName string) (utils.Values, error)
+	DeleteRelease(releaseNamespace string, releaseName string) error
+	ListReleasesNames(releaseNamespace string) ([]string, error)
+	IsReleaseExists(releaseNamespace string, releaseName string) (bool, error)
 }

--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"context"
 	"fmt"
+	"github.com/flant/addon-operator/pkg/app"
 	"os"
 	"path/filepath"
 	"sort"
@@ -860,6 +861,26 @@ func (bm *BasicModule) GetLastHookError() error {
 
 func (bm *BasicModule) GetModuleError() error {
 	return bm.state.lastModuleErr
+}
+
+// Read namespace from .namespace file in module dir
+// Return addon-operator namespace by default
+func (bm *BasicModule) GetDefaultOrDefinedNamespace() (string, error) {
+	content, err := os.ReadFile(filepath.Join(bm.Path, ".namespace"))
+	if err != nil {
+		if err != os.ErrNotExist {
+			return app.Namespace, fmt.Errorf("%s: %s", bm.Name, err)
+		} else {
+			log.Warnf("%s: .namespace not found, ignoring", bm.Name)
+			return app.Namespace, nil
+		}
+	}
+	namespace := strings.TrimRight(string(content), " \t\n")
+	if namespace != "" {
+		return namespace, nil
+	} else {
+		return app.Namespace, nil
+	}
 }
 
 type ModuleRunPhase string

--- a/pkg/module_manager/models/modules/values_storage.go
+++ b/pkg/module_manager/models/modules/values_storage.go
@@ -48,6 +48,7 @@ type ValuesStorage struct {
 	//   /modules/001-module/values.yaml
 	// are set only on module init phase
 	staticConfigValues utils.Values
+
 	// configValues are user defined values from KubeConfigManager (ConfigMap or ModuleConfig)
 	// without merge with static and openapi values
 	configValues utils.Values

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -532,7 +532,7 @@ func (mm *ModuleManager) RefreshStateFromHelmReleases(logLabels map[string]strin
 	if mm.dependencies.Helm == nil {
 		return &ModulesState{}, nil
 	}
-	releasedModules, err := mm.dependencies.Helm.NewClient(logLabels).ListReleasesNames()
+	releasedModules, err := mm.dependencies.Helm.NewClient(logLabels).ListReleasesNames("", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -728,7 +728,7 @@ func (mm *ModuleManager) DeleteModule(moduleName string, logLabels map[string]st
 		}
 		helmModule, _ := modules.NewHelmModule(ml, mm.TempDir, &hmdeps, mm.ValuesValidator)
 		if helmModule != nil {
-			releaseExists, err := mm.dependencies.Helm.NewClient(deleteLogLabels).IsReleaseExists(ml.GetName())
+			releaseExists, err := mm.dependencies.Helm.NewClient(deleteLogLabels).IsReleaseExists(helmModule.GetNamespace(), ml.GetName())
 			if !releaseExists {
 				if err != nil {
 					logEntry.Warnf("Cannot find helm release '%s' for module '%s'. Helm error: %s", ml.GetName(), ml.GetName(), err)
@@ -737,7 +737,7 @@ func (mm *ModuleManager) DeleteModule(moduleName string, logLabels map[string]st
 				}
 			} else {
 				// Chart and release are existed, so run helm delete command
-				err := mm.dependencies.Helm.NewClient(deleteLogLabels).DeleteRelease(ml.GetName())
+				err := mm.dependencies.Helm.NewClient(deleteLogLabels).DeleteRelease(helmModule.GetNamespace(), ml.GetName())
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
#### Overview

Added support for targeting namespaces. Related to [#336](https://github.com/flant/addon-operator/issues/336)

#### What this PR does / why we need it
- Allow to define namespace via `.namespace` file in module directory (similar to Deckhouse). If no file found, operator's namespace will be used.

#### Special notes for your reviewer
- Not implemented  in  helm3lib client module
