### PR TITLE
fix panic if hookcontrollers aren't set when disabling the module's hooks

### DIFF
--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -904,18 +904,25 @@ func (mm *ModuleManager) EnableModuleScheduleBindings(moduleName string) {
 	}
 }
 
+// DisableModuleHooks disables monitors/bindings of the module's hooks
+// It's advisable to use this method only if next step is to completely disable the module (as a short-term commitment).
+// Otherwise, as hooks are rather stateless, their confiuration may get overwritten, resulting in unexpected consequences.
 func (mm *ModuleManager) DisableModuleHooks(moduleName string) {
 	ml := mm.GetModule(moduleName)
 
 	kubeHooks := ml.GetHooks(OnKubernetesEvent)
 
 	for _, mh := range kubeHooks {
-		mh.GetHookController().StopMonitors()
+		if hc := mh.GetHookController(); hc != nil {
+			hc.StopMonitors()
+		}
 	}
 
 	schHooks := ml.GetHooks(Schedule)
 	for _, mh := range schHooks {
-		mh.GetHookController().DisableScheduleBindings()
+		if hc := mh.GetHookController(); hc != nil {
+			hc.DisableScheduleBindings()
+		}
 	}
 
 	mm.SetModulePhaseAndNotify(ml, modules.HooksDisabled)

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -910,19 +910,18 @@ func (mm *ModuleManager) EnableModuleScheduleBindings(moduleName string) {
 func (mm *ModuleManager) DisableModuleHooks(moduleName string) {
 	ml := mm.GetModule(moduleName)
 
-	kubeHooks := ml.GetHooks(OnKubernetesEvent)
+	if !ml.HooksControllersReady() {
+		return
+	}
 
+	kubeHooks := ml.GetHooks(OnKubernetesEvent)
 	for _, mh := range kubeHooks {
-		if hc := mh.GetHookController(); hc != nil {
-			hc.StopMonitors()
-		}
+		mh.GetHookController().StopMonitors()
 	}
 
 	schHooks := ml.GetHooks(Schedule)
 	for _, mh := range schHooks {
-		if hc := mh.GetHookController(); hc != nil {
-			hc.DisableScheduleBindings()
-		}
+		mh.GetHookController().DisableScheduleBindings()
 	}
 
 	mm.SetModulePhaseAndNotify(ml, modules.HooksDisabled)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
An additional check is added if the modules hooks have their controllers set before trying to invoke them
#### What this PR does / why we need it
A module's hooks architecture is still vulnerable to the situation when hooks are registered but their hook controllers haven't been set yet. Some calls like DisableModuleHooks imply that the hooks` controllers are already in place.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
