### PR TITLE
[addon-operator] add missing context to operator

### DIFF
--- a/cmd/addon-operator/main.go
+++ b/cmd/addon-operator/main.go
@@ -90,7 +90,7 @@ func start(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func run(_ context.Context, operator *addon_operator.AddonOperator) error {
+func run(ctx context.Context, operator *addon_operator.AddonOperator) error {
 	bk := configmap.New(log.StandardLogger(), operator.KubeClient(), app.Namespace, app.ConfigMapName)
 	operator.SetupKubeConfigManager(bk)
 
@@ -100,7 +100,7 @@ func run(_ context.Context, operator *addon_operator.AddonOperator) error {
 		os.Exit(1)
 	}
 
-	err = operator.Start()
+	err = operator.Start(ctx)
 	if err != nil {
 		fmt.Printf("Start is failed: %s\n", err)
 		os.Exit(1)

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -166,7 +166,8 @@ func (op *AddonOperator) Setup() error {
 }
 
 // Start runs all managers, event and queue handlers.
-func (op *AddonOperator) Start() error {
+// TODO: implement context in various dependencies (ModuleManager, KubeConfigManaer, etc)
+func (op *AddonOperator) Start(_ context.Context) error {
 	if err := op.bootstrap(); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
This pr adds a context argument to the operator's Start method.
#### What this PR does / why we need it
It should be considered as a general improvement (using context is encouraged). Also, the method could be used as a [runnable](https://github.com/kubernetes-sigs/controller-runtime/blob/2e9781e9fc6054387cf0901c70db56f0b0a63083/pkg/manager/runnable_group.go#L30) for the controller-runtime manager at start up, allowing an elegant embedding of the operator's logic.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
