### PR TITLE
Fix extender errors handling

### DIFF
--- a/pkg/module_manager/scheduler/extenders/dynamically_enabled/dynamic.go
+++ b/pkg/module_manager/scheduler/extenders/dynamically_enabled/dynamic.go
@@ -72,6 +72,10 @@ func (e *Extender) Filter(moduleName string, _ map[string]string) (*bool, error)
 	return nil, nil
 }
 
+func (e *Extender) IsTerminator() bool {
+	return false
+}
+
 func (e *Extender) SetNotifyChannel(_ context.Context, ch chan extenders.ExtenderEvent) {
 	e.notifyCh = ch
 }

--- a/pkg/module_manager/scheduler/extenders/error/permanent.go
+++ b/pkg/module_manager/scheduler/extenders/error/permanent.go
@@ -15,6 +15,9 @@ func (e *PermanentError) Unwrap() error {
 
 // Permanent wraps the given err in a *PermanentError.
 func Permanent(err error) *PermanentError {
+	if err == nil {
+		return nil
+	}
 	return &PermanentError{
 		Err: err,
 	}

--- a/pkg/module_manager/scheduler/extenders/error/permanent.go
+++ b/pkg/module_manager/scheduler/extenders/error/permanent.go
@@ -1,0 +1,21 @@
+package error
+
+// PermanentError signals that the operation should stop the module manager immediately
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PermanentError) Unwrap() error {
+	return e.Err
+}
+
+// Permanent wraps the given err in a *PermanentError.
+func Permanent(err error) *PermanentError {
+	return &PermanentError{
+		Err: err,
+	}
+}

--- a/pkg/module_manager/scheduler/extenders/extenders.go
+++ b/pkg/module_manager/scheduler/extenders/extenders.go
@@ -16,6 +16,9 @@ type Extender interface {
 	Name() ExtenderName
 	// Filter returns the result of applying the extender
 	Filter(moduleName string, logLabels map[string]string) (*bool, error)
+	// IsTerminator marks extender that can only disable an enabled module if some requirement isn't met.
+	// By design, terminators can't be overridden by other extenders.
+	IsTerminator() bool
 }
 
 type NotificationExtender interface {
@@ -27,12 +30,4 @@ type NotificationExtender interface {
 type ResettableExtender interface {
 	// Reset resets the extender's cache
 	Reset()
-}
-
-// Type of extenders that can only disable an enabled module if some requirement isn't met.
-// By design, it makes sense to run terminators in the end of filtering because terminators can't be overridden by other extenders.
-// For example, enabled scripts extender.
-type TerminatingExtender interface {
-	// Just a signature to match extenders
-	IsTerminator()
 }

--- a/pkg/module_manager/scheduler/extenders/kube_config/kube_config.go
+++ b/pkg/module_manager/scheduler/extenders/kube_config/kube_config.go
@@ -29,12 +29,16 @@ func NewExtender(kcm kubeConfigManager) *Extender {
 	return e
 }
 
-func (e Extender) Name() extenders.ExtenderName {
+func (e *Extender) Name() extenders.ExtenderName {
 	return Name
 }
 
-func (e Extender) Filter(moduleName string, _ map[string]string) (*bool, error) {
+func (e *Extender) Filter(moduleName string, _ map[string]string) (*bool, error) {
 	return e.kubeConfigManager.IsModuleEnabled(moduleName), nil
+}
+
+func (e *Extender) IsTerminator() bool {
+	return false
 }
 
 func (e *Extender) sendNotify(kubeConfigEvent config.KubeConfigEvent) {

--- a/pkg/module_manager/scheduler/extenders/script_enabled/script.go
+++ b/pkg/module_manager/scheduler/extenders/script_enabled/script.go
@@ -129,7 +129,10 @@ func (e *Extender) Filter(moduleName string, logLabels map[string]string) (*bool
 			e.enabledModules = append(e.enabledModules, moduleDescriptor.module.GetName())
 			e.l.Unlock()
 		}
-		return enabled, exerror.Permanent(err)
+		if err != nil {
+			return enabled, exerror.Permanent(err)
+		}
+		return enabled, nil
 	}
 	return nil, nil
 }

--- a/pkg/module_manager/scheduler/extenders/script_enabled/script_test.go
+++ b/pkg/module_manager/scheduler/extenders/script_enabled/script_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	exerror "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/error"
 	node_mock "github.com/flant/addon-operator/pkg/module_manager/scheduler/node/mock"
 )
 
@@ -78,7 +79,7 @@ func TestExtender(t *testing.T) {
 			assert.Equal(t, nil, err)
 		case "node-local-dns":
 			assert.Equal(t, false, *enabled)
-			assert.Equal(t, errors.New("Failed to execute 'node-local-dns' module's enabled script: Exit code 1"), err)
+			assert.Equal(t, &exerror.PermanentError{Err: errors.New("failed to execute 'node-local-dns' module's enabled script: Exit code 1")}, err)
 		case "admission-policy-engine", "chrony":
 			assert.Equal(t, false, *enabled)
 			assert.Equal(t, nil, err)

--- a/pkg/module_manager/scheduler/extenders/static/static.go
+++ b/pkg/module_manager/scheduler/extenders/static/static.go
@@ -70,14 +70,18 @@ func NewExtender(staticValuesFilePaths string) (*Extender, error) {
 	return e, nil
 }
 
-func (e Extender) Name() extenders.ExtenderName {
+func (e *Extender) Name() extenders.ExtenderName {
 	return Name
 }
 
-func (e Extender) Filter(moduleName string, _ map[string]string) (*bool, error) {
+func (e *Extender) Filter(moduleName string, _ map[string]string) (*bool, error) {
 	if val, found := e.modulesStatus[moduleName]; found {
 		return &val, nil
 	}
 
 	return nil, nil
+}
+
+func (e *Extender) IsTerminator() bool {
+	return true
 }

--- a/pkg/module_manager/scheduler/extenders/static/static.go
+++ b/pkg/module_manager/scheduler/extenders/static/static.go
@@ -83,5 +83,5 @@ func (e *Extender) Filter(moduleName string, _ map[string]string) (*bool, error)
 }
 
 func (e *Extender) IsTerminator() bool {
-	return true
+	return false
 }

--- a/pkg/module_manager/scheduler/scheduler.go
+++ b/pkg/module_manager/scheduler/scheduler.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	exerror "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/error"
-
 	"github.com/dominikbraun/graph"
 	"github.com/dominikbraun/graph/draw"
 	"github.com/goccy/go-graphviz"
@@ -19,6 +17,7 @@ import (
 
 	"github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders"
 	dynamic_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/dynamically_enabled"
+	exerror "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/error"
 	kube_config_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/kube_config"
 	script_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/script_enabled"
 	static_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/static"

--- a/pkg/module_manager/scheduler/scheduler_test.go
+++ b/pkg/module_manager/scheduler/scheduler_test.go
@@ -709,7 +709,7 @@ l2LoadBalancerEnabled: false
 	assert.Equal(t, expected, summary)
 	assert.Equal(t, expectedDiff, diff)
 	assert.Equal(t, expectedVerticesToUpdate, verticesToUpdate)
-	assert.Equal(t, []string{"Failed to execute 'ingress-nginx' module's enabled script: Exit code not 0"}, s.errList)
+	assert.Equal(t, []string{"failed to execute 'ingress-nginx' module's enabled script: Exit code not 0"}, s.errList)
 
 	err = os.RemoveAll(tmp)
 	assert.NoError(t, err)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Fix scheduler's errors handling

#### What this PR does / why we need it

We want to have a kind of filter error that would not stop the module manager and could be passed to an extender.
Scheduler will stop only on permanent errors

#### Special notes for your reviewer
