### PR TITLE
Execute ModuleRun tasks of the same weight in parallel

### DIFF
--- a/pkg/addon-operator/converge/converge.go
+++ b/pkg/addon-operator/converge/converge.go
@@ -72,7 +72,7 @@ func IsConvergeTask(t sh_task.Task) bool {
 	switch taskType {
 	case task.ModuleDelete, task.ConvergeModules:
 		return true
-	case task.ModuleRun, task.GroupedModuleRun:
+	case task.ModuleRun, task.ParallelModuleRun:
 		return hm.IsReloadAll
 	case task.GlobalHookRun:
 		switch hm.BindingType {

--- a/pkg/addon-operator/converge/converge.go
+++ b/pkg/addon-operator/converge/converge.go
@@ -72,7 +72,7 @@ func IsConvergeTask(t sh_task.Task) bool {
 	switch taskType {
 	case task.ModuleDelete, task.ConvergeModules:
 		return true
-	case task.ModuleRun:
+	case task.ModuleRun, task.GroupedModuleRun:
 		return hm.IsReloadAll
 	case task.GlobalHookRun:
 		switch hm.BindingType {

--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"path"
 	"runtime/trace"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
@@ -28,6 +30,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules/events"
 	dynamic_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/dynamically_enabled"
+	"github.com/flant/addon-operator/pkg/module_manager/scheduler/node"
 	"github.com/flant/addon-operator/pkg/task"
 	"github.com/flant/addon-operator/pkg/utils"
 	"github.com/flant/kube-client/client"
@@ -58,6 +61,9 @@ type AddonOperator struct {
 	cancel context.CancelFunc
 
 	runtimeConfig *runtimeConfig.Config
+
+	// a map of channels to communicate with group queues and its lock
+	groupedTaskChannels groupedTaskChannels
 
 	DebugServer *debug.Server
 
@@ -90,6 +96,36 @@ type AddonOperator struct {
 	// CRDExtraLabels contains labels for processing CRD files
 	// like heritage=addon-operator
 	CRDExtraLabels map[string]string
+}
+
+type groupQueueEvent struct {
+	moduleName string
+	errMsg     string
+	succeeded  bool
+}
+
+type groupedTaskChannels struct {
+	l        sync.Mutex
+	channels map[string]chan groupQueueEvent
+}
+
+func (gq *groupedTaskChannels) Set(id string, c chan groupQueueEvent) {
+	gq.l.Lock()
+	gq.channels[id] = c
+	gq.l.Unlock()
+}
+
+func (gq *groupedTaskChannels) Get(id string) (chan groupQueueEvent, bool) {
+	gq.l.Lock()
+	defer gq.l.Unlock()
+	c, ok := gq.channels[id]
+	return c, ok
+}
+
+func (gq *groupedTaskChannels) Delete(id string) {
+	gq.l.Lock()
+	delete(gq.channels, id)
+	gq.l.Unlock()
 }
 
 func NewAddonOperator(ctx context.Context) *AddonOperator {
@@ -134,6 +170,9 @@ func NewAddonOperator(ctx context.Context) *AddonOperator {
 		runtimeConfig:  rc,
 		MetricStorage:  so.MetricStorage,
 		CRDExtraLabels: crdExtraLabels,
+		groupedTaskChannels: groupedTaskChannels{
+			channels: make(map[string](chan groupQueueEvent)),
+		},
 	}
 
 	ao.AdmissionServer = NewAdmissionServer(app.AdmissionServerListenPort, app.AdmissionServerCertsDir)
@@ -203,6 +242,8 @@ func (op *AddonOperator) Start(_ context.Context) error {
 	op.BootstrapMainQueue(op.engine.TaskQueues)
 	// Start main task queue handler
 	op.engine.TaskQueues.StartMain()
+	// Precreate queues for grouped tasks
+	op.CreateAndStartGroupQueues()
 
 	// Global hooks are registered, initialize their queues.
 	op.CreateAndStartQueuesForGlobalHooks()
@@ -925,6 +966,19 @@ func (op *AddonOperator) CreateAndStartQueuesForModuleHooks(moduleName string) {
 	//}
 }
 
+// CreateAndStartGroupQueues creates and starts named queues for executing grouped tasks in parallel
+func (op *AddonOperator) CreateAndStartGroupQueues() {
+	for i := 0; i < app.NumberOfGroupQueues; i++ {
+		queueName := fmt.Sprintf(app.GroupQueueNamePattern, i)
+		if op.engine.TaskQueues.GetByName(queueName) != nil {
+			log.Warnf("Group queue %s already exists", queueName)
+			continue
+		}
+		op.engine.TaskQueues.NewNamedQueue(queueName, op.GroupedTasksHandler)
+		op.engine.TaskQueues.GetByName(queueName).Start()
+	}
+}
+
 func (op *AddonOperator) DrainModuleQueues(modName string) {
 	m := op.ModuleManager.GetModule(modName)
 	if m == nil {
@@ -988,9 +1042,8 @@ func (op *AddonOperator) StartModuleManagerEventHandler() {
 							converge.ReloadAllModules,
 							logLabels,
 						)
-						firstTask := op.engine.TaskQueues.GetMain().GetFirst()
 						// if converge has already begun - restart it immediately
-						if firstTask != nil && RemoveCurrentConvergeTasks(op.engine.TaskQueues.GetMain(), firstTask.GetId(), logLabels) && op.ConvergeState.Phase != converge.StandBy {
+						if op.engine.TaskQueues.GetMain().Length() > 0 && RemoveCurrentConvergeTasks(op.getConvergeQueues(), logLabels) && op.ConvergeState.Phase != converge.StandBy {
 							logEntry.Infof("ConvergeModules: global hook dynamic modification detected, restart current converge process (%s)", op.ConvergeState.Phase)
 							op.engine.TaskQueues.GetMain().AddFirst(convergeTask)
 							op.logTaskAdd(eventLogEntry, "DynamicExtender is updated, put first", convergeTask)
@@ -1061,10 +1114,8 @@ func (op *AddonOperator) StartModuleManagerEventHandler() {
 								converge.ReloadAllModules,
 								logLabels,
 							)
-							// check if main queue is empty
-							firstTask := op.engine.TaskQueues.GetMain().GetFirst()
 							// if main queue isn't empty and there was another convergeModules task:
-							if firstTask != nil && RemoveCurrentConvergeTasks(op.engine.TaskQueues.GetMain(), firstTask.GetId(), logLabels) {
+							if op.engine.TaskQueues.GetMain().Length() > 0 && RemoveCurrentConvergeTasks(op.getConvergeQueues(), logLabels) {
 								logEntry.Infof("ConvergeModules: kube config modification detected,  restart current converge process (%s)", op.ConvergeState.Phase)
 								// put ApplyKubeConfig->NewConvergeModulesTask sequence in the beginning of the main queue
 								if kubeConfigTask != nil {
@@ -1147,6 +1198,48 @@ func (op *AddonOperator) StartModuleManagerEventHandler() {
 	}()
 }
 
+// GroupedTasksHandler handles limited types of tasks in group queues.
+func (op *AddonOperator) GroupedTasksHandler(t sh_task.Task) queue.TaskResult {
+	taskLogLabels := t.GetLogLabels()
+	taskLogEntry := log.WithFields(utils.LabelsToLogFields(taskLogLabels))
+	var res queue.TaskResult
+
+	op.logTaskStart(taskLogEntry, t)
+
+	op.UpdateWaitInQueueMetric(t)
+
+	switch t.GetType() {
+	case task.ModuleRun:
+		res = op.HandleModuleRun(t, taskLogLabels)
+
+	case task.ModuleHookRun:
+		res = op.HandleModuleHookRun(t, taskLogLabels)
+	}
+
+	op.logTaskEnd(taskLogEntry, t, res)
+	hm := task.HookMetadataAccessor(t)
+	if hm.GroupMetadata == nil || len(hm.GroupMetadata.ChannelId) == 0 {
+		taskLogEntry.Warn("Grouped task had no communication channel set")
+	}
+
+	if groupChannel, ok := op.groupedTaskChannels.Get(hm.GroupMetadata.ChannelId); ok {
+		if res.Status == queue.Fail {
+			groupChannel <- groupQueueEvent{
+				moduleName: hm.ModuleName,
+				errMsg:     t.GetFailureMessage(),
+				succeeded:  false,
+			}
+		}
+		if res.Status == queue.Success && t.GetType() == task.ModuleRun && len(res.AfterTasks) == 0 {
+			groupChannel <- groupQueueEvent{
+				moduleName: hm.ModuleName,
+				succeeded:  true,
+			}
+		}
+	}
+	return res
+}
+
 // TaskHandler handles tasks in queue.
 func (op *AddonOperator) TaskHandler(t sh_task.Task) queue.TaskResult {
 	taskLogLabels := t.GetLogLabels()
@@ -1172,7 +1265,7 @@ func (op *AddonOperator) TaskHandler(t sh_task.Task) queue.TaskResult {
 
 	case task.GlobalHookWaitKubernetesSynchronization:
 		res.Status = queue.Success
-		if op.ModuleManager.GlobalSynchronizationNeeded() && !op.ModuleManager.GlobalSynchronizationState().IsComplete() {
+		if op.ModuleManager.GlobalSynchronizationNeeded() && !op.ModuleManager.GlobalSynchronizationState().IsCompleted() {
 			// dump state
 			op.ModuleManager.GlobalSynchronizationState().DebugDumpState(taskLogEntry)
 			t.WithQueuedAt(time.Now())
@@ -1192,6 +1285,9 @@ func (op *AddonOperator) TaskHandler(t sh_task.Task) queue.TaskResult {
 
 	case task.ModuleRun:
 		res = op.HandleModuleRun(t, taskLogLabels)
+
+	case task.GroupedModuleRun:
+		res = op.HandleGroupedModuleRun(t, taskLogLabels)
 
 	case task.ModuleDelete:
 		res.Status = op.HandleModuleDelete(t, taskLogLabels)
@@ -1487,6 +1583,108 @@ func (op *AddonOperator) HandleModuleEnsureCRDs(t sh_task.Task, labels map[strin
 	return
 }
 
+// HandleGroupedModuleRun runs multiple HandleModuleRun tasks in parallel and aggregates their results
+func (op *AddonOperator) HandleGroupedModuleRun(t sh_task.Task, labels map[string]string) (res queue.TaskResult) {
+	defer trace.StartRegion(context.Background(), "GroupModuleRun").End()
+	logEntry := log.WithFields(utils.LabelsToLogFields(labels))
+	hm := task.HookMetadataAccessor(t)
+
+	if hm.GroupMetadata == nil {
+		logEntry.Errorf("Possible bug! Couldn't get task GroupMetadata for a grouped task: %s", hm.EventDescription)
+		res.Status = queue.Fail
+		return res
+	}
+
+	i := 0
+	groupChannel := make(chan groupQueueEvent)
+	op.groupedTaskChannels.Set(t.GetId(), groupChannel)
+	logEntry.Debugf("GroupedModuleRun available group event channels %v", op.groupedTaskChannels.channels)
+	for moduleName, moduleMetadata := range hm.GroupMetadata.GetModulesMetadata() {
+		queueName := fmt.Sprintf(app.GroupQueueNamePattern, i%(app.NumberOfGroupQueues-1))
+		newLogLabels := utils.MergeLabels(labels)
+		newLogLabels["module"] = moduleName
+		delete(newLogLabels, "task.id")
+		newTask := sh_task.NewTask(task.ModuleRun).
+			WithLogLabels(newLogLabels).
+			WithQueueName(queueName).
+			WithMetadata(task.HookMetadata{
+				EventDescription: hm.EventDescription,
+				ModuleName:       moduleName,
+				DoModuleStartup:  moduleMetadata.DoModuleStartup,
+				IsReloadAll:      hm.IsReloadAll,
+				GroupMetadata: &task.GroupMetadata{
+					ChannelId: t.GetId(),
+				},
+			})
+		op.engine.TaskQueues.GetByName(queueName).AddLast(newTask)
+		i++
+	}
+
+	// map to hold modules' errors
+	tasksErrors := make(map[string]string)
+L:
+	for {
+		select {
+		case groupEvent := <-groupChannel:
+			logEntry.Debugf("GroupedModuleRun event '%v' received", groupEvent)
+			if len(groupEvent.errMsg) != 0 {
+				if tasksErrors[groupEvent.moduleName] != groupEvent.errMsg {
+					tasksErrors[groupEvent.moduleName] = groupEvent.errMsg
+					t.UpdateFailureMessage(formatErrorSummary(tasksErrors))
+				}
+				t.IncrementFailureCount()
+				continue L
+			}
+			if groupEvent.succeeded {
+				hm.GroupMetadata.DeleteModuleMetadata(groupEvent.moduleName)
+				// all ModuleRun tasks were executed successfully
+				if len(hm.GroupMetadata.GetModulesMetadata()) == 0 {
+					break L
+				}
+				delete(tasksErrors, groupEvent.moduleName)
+				t.UpdateFailureMessage(formatErrorSummary(tasksErrors))
+				newMeta := task.HookMetadata{
+					EventDescription: hm.EventDescription,
+					ModuleName:       fmt.Sprintf("Grouped run for %s", strings.Join(hm.GroupMetadata.ListModules(), ", ")),
+					IsReloadAll:      hm.IsReloadAll,
+					GroupMetadata:    hm.GroupMetadata,
+				}
+				t.UpdateMetadata(newMeta)
+			}
+
+		case <-hm.GroupMetadata.Context.Done():
+			logEntry.Debug("GroupedModuleRun context canceled")
+			// remove channel from map so that ModuleRun handlers couldn't send into it
+			op.groupedTaskChannels.Delete(t.GetId())
+			t := time.NewTimer(time.Second * 3)
+			for {
+				select {
+				// wait for several seconds if any ModuleRun task wants to send an event
+				case <-t.C:
+					logEntry.Debug("GroupedModuleRun task aborted")
+					res.Status = queue.Success
+					return res
+
+				// drain channel to unblock handlers if any
+				case <-groupChannel:
+				}
+			}
+		}
+	}
+	op.groupedTaskChannels.Delete(t.GetId())
+	res.Status = queue.Success
+	return res
+}
+
+// fomartErrorSumamry constructs a string of errors from the map
+func formatErrorSummary(errors map[string]string) string {
+	errSummary := "\n\tErrors:\n"
+	for moduleName, moduleErr := range errors {
+		errSummary += fmt.Sprintf("\t- %s: %s", moduleName, moduleErr)
+	}
+	return errSummary
+}
+
 // HandleModuleRun starts a module by executing module hooks and installing a Helm chart.
 //
 // Execution sequence:
@@ -1575,6 +1773,10 @@ func (op *AddonOperator) HandleModuleRun(t sh_task.Task, labels map[string]strin
 		// Start monitors for each kubernetes binding in each module hook.
 		err := op.ModuleManager.HandleModuleEnableKubernetesBindings(hm.ModuleName, func(hook *hooks.ModuleHook, info controller.BindingExecutionInfo) {
 			queueName := info.QueueName
+			if queueName == "main" && strings.HasPrefix(t.GetQueueName(), app.GroupQueuePrefix) {
+				// override main queue with group_queue
+				queueName = t.GetQueueName()
+			}
 			taskLogLabels := utils.MergeLabels(t.GetLogLabels(), map[string]string{
 				"binding":   string(htypes.OnKubernetesEvent) + "Synchronization",
 				"module":    hm.ModuleName,
@@ -1588,6 +1790,10 @@ func (op *AddonOperator) HandleModuleRun(t sh_task.Task, labels map[string]strin
 			delete(taskLogLabels, "task.id")
 
 			kubernetesBindingID := uuid.Must(uuid.NewV4()).String()
+			groupMetadata := &task.GroupMetadata{}
+			if hm.GroupMetadata != nil && len(hm.GroupMetadata.ChannelId) != 0 {
+				groupMetadata.ChannelId = hm.GroupMetadata.ChannelId
+			}
 			taskMeta := task.HookMetadata{
 				EventDescription:         hm.EventDescription,
 				ModuleName:               hm.ModuleName,
@@ -1599,6 +1805,7 @@ func (op *AddonOperator) HandleModuleRun(t sh_task.Task, labels map[string]strin
 				WaitForSynchronization:   info.KubernetesBinding.WaitForSynchronization,
 				MonitorIDs:               []string{info.KubernetesBinding.Monitor.Metadata.MonitorId},
 				ExecuteOnSynchronization: info.KubernetesBinding.ExecuteHookOnSynchronization,
+				GroupMetadata:            groupMetadata,
 			}
 			newTask := sh_task.NewTask(task.ModuleHookRun).
 				WithLogLabels(taskLogLabels).
@@ -1606,7 +1813,7 @@ func (op *AddonOperator) HandleModuleRun(t sh_task.Task, labels map[string]strin
 				WithMetadata(taskMeta)
 			newTask.WithQueuedAt(time.Now())
 
-			if info.QueueName == t.GetQueueName() {
+			if queueName == t.GetQueueName() {
 				// Ignore "waitForSynchronization: false" for hooks in the main queue.
 				// There is no way to not wait for these hooks.
 				mainSyncTasks = append(mainSyncTasks, newTask)
@@ -1671,17 +1878,17 @@ func (op *AddonOperator) HandleModuleRun(t sh_task.Task, labels map[string]strin
 
 	// Repeat ModuleRun if there are running Synchronization tasks to wait.
 	if baseModule.GetPhase() == modules.WaitForSynchronization {
-		if baseModule.Synchronization().IsComplete() {
+		if baseModule.Synchronization().IsCompleted() {
 			// Proceed with the next phase.
 			op.ModuleManager.SetModulePhaseAndNotify(baseModule, modules.EnableScheduleBindings)
 			logEntry.Info("Synchronization done for module hooks")
 		} else {
 			// Debug messages every fifth second: print Synchronization state.
 			if time.Now().UnixNano()%5000000000 == 0 {
-				logEntry.Debugf("ModuleRun wait Synchronization state: moduleStartup:%v syncNeeded:%v syncQueued:%v syncDone:%v", hm.DoModuleStartup, baseModule.SynchronizationNeeded(), baseModule.Synchronization().HasQueued(), baseModule.Synchronization().IsComplete())
+				logEntry.Debugf("ModuleRun wait Synchronization state: moduleStartup:%v syncNeeded:%v syncQueued:%v syncDone:%v", hm.DoModuleStartup, baseModule.SynchronizationNeeded(), baseModule.Synchronization().HasQueued(), baseModule.Synchronization().IsCompleted())
 				baseModule.Synchronization().DebugDumpState(logEntry)
 			}
-			logEntry.Debugf("Synchronization not complete, keep ModuleRun task in repeat mode")
+			logEntry.Debugf("Synchronization not completed, keep ModuleRun task in repeat mode")
 			t.WithQueuedAt(time.Now())
 			res.Status = queue.Repeat
 			return
@@ -2155,12 +2362,14 @@ func (op *AddonOperator) CreateReloadModulesTasks(moduleNames []string, logLabel
 	return newTasks
 }
 
-// CreateConvergeModulesTasks creates ModuleRun/ModuleDelete tasks based on moduleManager state.
+// CreateConvergeModulesTasks creates EnsureCRDsTasks and ModuleRun/ModuleDelete tasks based on moduleManager state.
 func (op *AddonOperator) CreateConvergeModulesTasks(state *module_manager.ModulesState, logLabels map[string]string, eventDescription string) []sh_task.Task {
-	newTasks := make([]sh_task.Task, 0, len(state.ModulesToDisable)+len(state.AllEnabledModules))
+	modulesTasks := make([]sh_task.Task, 0, len(state.ModulesToDisable)+len(state.AllEnabledModules))
+	resultingTasks := make([]sh_task.Task, 0, len(state.ModulesToDisable)+len(state.AllEnabledModules))
 	queuedAt := time.Now()
 
 	// Add ModuleDelete tasks to delete helm releases of disabled modules.
+	log.Debugf("The following modules are going to be disabled: %v", state.ModulesToDisable)
 	for _, moduleName := range state.ModulesToDisable {
 		ev := events.ModuleEvent{
 			ModuleName: moduleName,
@@ -2178,58 +2387,110 @@ func (op *AddonOperator) CreateConvergeModulesTasks(state *module_manager.Module
 				EventDescription: eventDescription,
 				ModuleName:       moduleName,
 			})
-		newTasks = append(newTasks, newTask.WithQueuedAt(queuedAt))
+		modulesTasks = append(modulesTasks, newTask.WithQueuedAt(queuedAt))
 	}
 
-	ensureCRDsTasks := make([]sh_task.Task, 0, len(state.AllEnabledModules))
 	// Add ModuleRun tasks to install or reload enabled modules.
 	newlyEnabled := utils.ListToMapStringStruct(state.ModulesToEnable)
-	for _, moduleName := range state.AllEnabledModules {
-		ev := events.ModuleEvent{
-			ModuleName: moduleName,
-			EventType:  events.ModuleEnabled,
-		}
-		op.ModuleManager.SendModuleEvent(ev)
-		newLogLabels := utils.MergeLabels(logLabels)
-		newLogLabels["module"] = moduleName
-		delete(newLogLabels, "task.id")
-
-		// Run OnStartup and Kubernetes.Synchronization hooks
-		// on application startup or if module become enabled.
-		doModuleStartup := false
-		if _, has := newlyEnabled[moduleName]; has {
-			doModuleStartup = true
-
-			// create ensureCRDsTasks only for newlyEnabled modules
-			// and if module contains CRDs
-			if op.ModuleManager.ModuleHasCRDs(moduleName) {
-				ensureCRDsTasks = append(ensureCRDsTasks, sh_task.NewTask(task.ModuleEnsureCRDs).
-					WithLogLabels(newLogLabels).
-					WithQueueName("main").
-					WithMetadata(task.HookMetadata{
-						EventDescription: "EnsureCRDs",
-						ModuleName:       moduleName,
-						IsReloadAll:      true,
-					}).WithQueuedAt(queuedAt))
-			}
-		}
-
-		newTask := sh_task.NewTask(task.ModuleRun).
-			WithLogLabels(newLogLabels).
-			WithQueueName("main").
-			WithMetadata(task.HookMetadata{
-				EventDescription: eventDescription,
-				ModuleName:       moduleName,
-				DoModuleStartup:  doModuleStartup,
-				IsReloadAll:      true,
-			})
-		newTasks = append(newTasks, newTask.WithQueuedAt(queuedAt))
+	log.Debugf("The following modules are going to be enabled/rerun: %v", state.AllEnabledModulesByOrder)
+	// sort modules' orders
+	sortedOrders := make([]node.NodeWeight, 0, len(state.AllEnabledModulesByOrder))
+	for order := range state.AllEnabledModulesByOrder {
+		sortedOrders = append(sortedOrders, order)
 	}
+	sort.Slice(sortedOrders, func(i, j int) bool { return sortedOrders[i] < sortedOrders[j] })
 
-	// append ensureCRDs tasks to begin queue
-	ensureCRDsTasks = append(ensureCRDsTasks, newTasks...)
+	for _, order := range sortedOrders {
+		newLogLabels := utils.MergeLabels(logLabels)
+		delete(newLogLabels, "task.id")
+		modules := state.AllEnabledModulesByOrder[order]
+		// create grouped moduleRun task
+		switch {
+		case len(modules) > 1:
+			newLogLabels["modules"] = strings.Join(modules, ",")
+			newLogLabels["order"] = order.String()
+			groupMetadata := task.GroupMetadata{
+				Order: order,
+			}
+			for _, moduleName := range modules {
+				ev := events.ModuleEvent{
+					ModuleName: moduleName,
+					EventType:  events.ModuleEnabled,
+				}
+				op.ModuleManager.SendModuleEvent(ev)
+				doModuleStartup := false
+				if _, has := newlyEnabled[moduleName]; has {
+					// add EnsureCRDs task if module is about to be enabled
+					if op.ModuleManager.ModuleHasCRDs(moduleName) {
+						resultingTasks = append(resultingTasks, sh_task.NewTask(task.ModuleEnsureCRDs).
+							WithLogLabels(newLogLabels).
+							WithQueueName("main").
+							WithMetadata(task.HookMetadata{
+								EventDescription: "EnsureCRDs",
+								ModuleName:       moduleName,
+								IsReloadAll:      true,
+							}).WithQueuedAt(queuedAt))
+					}
+					doModuleStartup = true
+				}
+				groupMetadata.SetModuleMetadata(moduleName, task.GroupedModuleMetadata{
+					DoModuleStartup: doModuleStartup,
+				})
+			}
+			groupMetadata.Context, groupMetadata.CancelF = context.WithCancel(context.Background())
+			newTask := sh_task.NewTask(task.GroupedModuleRun).
+				WithLogLabels(newLogLabels).
+				WithQueueName("main").
+				WithMetadata(task.HookMetadata{
+					EventDescription: eventDescription,
+					ModuleName:       fmt.Sprintf("Grouped run for %s", strings.Join(modules, ", ")),
+					IsReloadAll:      true,
+					GroupMetadata:    &groupMetadata,
+				})
+			modulesTasks = append(modulesTasks, newTask.WithQueuedAt(queuedAt))
 
-	return ensureCRDsTasks
+		// otherwise, create an original moduleRun task
+		case len(modules) == 1:
+			ev := events.ModuleEvent{
+				ModuleName: modules[0],
+				EventType:  events.ModuleEnabled,
+			}
+			op.ModuleManager.SendModuleEvent(ev)
+			newLogLabels["module"] = modules[0]
+			doModuleStartup := false
+			if _, has := newlyEnabled[modules[0]]; has {
+				// add EnsureCRDs task if module is about to be enabled
+				if op.ModuleManager.ModuleHasCRDs(modules[0]) {
+					resultingTasks = append(resultingTasks, sh_task.NewTask(task.ModuleEnsureCRDs).
+						WithLogLabels(newLogLabels).
+						WithQueueName("main").
+						WithMetadata(task.HookMetadata{
+							EventDescription: "EnsureCRDs",
+							ModuleName:       modules[0],
+							IsReloadAll:      true,
+						}).WithQueuedAt(queuedAt))
+				}
+				doModuleStartup = true
+			}
+			newTask := sh_task.NewTask(task.ModuleRun).
+				WithLogLabels(newLogLabels).
+				WithQueueName("main").
+				WithMetadata(task.HookMetadata{
+					EventDescription: eventDescription,
+					ModuleName:       modules[0],
+					DoModuleStartup:  doModuleStartup,
+					IsReloadAll:      true,
+				})
+			modulesTasks = append(modulesTasks, newTask.WithQueuedAt(queuedAt))
+
+		default:
+			log.Errorf("Invalid ModulesState %v", state)
+		}
+	}
+	// append modulesTasks to resultingTasks
+	resultingTasks = append(resultingTasks, modulesTasks...)
+
+	return resultingTasks
 }
 
 // CheckConvergeStatus detects if converge process is started and
@@ -2358,6 +2619,9 @@ func taskDescriptionForTaskFlowLog(tsk sh_task.Task, action string, phase string
 			parts = append(parts, "with doModuleStartup")
 		}
 
+	case task.GroupedModuleRun:
+		parts = append(parts, fmt.Sprintf("modules '%s'", hm.ModuleName))
+
 	case task.ModulePurge, task.ModuleDelete:
 		parts = append(parts, fmt.Sprintf("module '%s'", hm.ModuleName))
 
@@ -2442,4 +2706,14 @@ func (op *AddonOperator) taskPhase(tsk sh_task.Task) string {
 		return string(mod.GetPhase())
 	}
 	return ""
+}
+
+// getConvergeQueues returns list of all queues where modules converge tasks may be running
+func (op *AddonOperator) getConvergeQueues() []*queue.TaskQueue {
+	convergeQueues := make([]*queue.TaskQueue, 0, app.NumberOfGroupQueues+1)
+	for i := 0; i < app.NumberOfGroupQueues; i++ {
+		convergeQueues = append(convergeQueues, op.engine.TaskQueues.GetByName(fmt.Sprintf(app.GroupQueueNamePattern, i)))
+	}
+	convergeQueues = append(convergeQueues, op.engine.TaskQueues.GetMain())
+	return convergeQueues
 }

--- a/pkg/addon-operator/queue.go
+++ b/pkg/addon-operator/queue.go
@@ -44,9 +44,9 @@ func ModulesWithPendingModuleRun(q *queue.TaskQueue) map[string]struct{} {
 			hm := task.HookMetadataAccessor(t)
 			modules[hm.ModuleName] = struct{}{}
 
-		case task.GroupedModuleRun:
+		case task.ParallelModuleRun:
 			hm := task.HookMetadataAccessor(t)
-			for _, moduleName := range hm.GroupMetadata.ListModules() {
+			for _, moduleName := range hm.ParallelRunMetadata.ListModules() {
 				modules[moduleName] = struct{}{}
 			}
 		}
@@ -86,7 +86,7 @@ func ConvergeModulesInQueue(q *queue.TaskQueue) int {
 	return tasks
 }
 
-// RemoveCurrentConvergeTasks detects if converge tasks present in the main and group queues.
+// RemoveCurrentConvergeTasks detects if converge tasks present in the main and parallel queues.
 // These tasks are drained and the method returns true
 func RemoveCurrentConvergeTasks(convergeQueues []*queue.TaskQueue, logLabels map[string]string) bool {
 	logEntry := log.WithFields(utils.LabelsToLogFields(logLabels))
@@ -112,12 +112,12 @@ func RemoveCurrentConvergeTasks(convergeQueues []*queue.TaskQueue, logLabels map
 				case task.ConvergeModules:
 					stop = true
 
-				case task.GroupedModuleRun:
-					if hm.GroupMetadata == nil || hm.GroupMetadata.CancelF == nil {
-						logEntry.Warnf("Couldn't get group metadata for group task of type: %s, module: %s, description: %s, from queue %s", t.GetType(), hm.ModuleName, hm.EventDescription, queue.Name)
+				case task.ParallelModuleRun:
+					if hm.ParallelRunMetadata == nil || hm.ParallelRunMetadata.CancelF == nil {
+						logEntry.Warnf("Couldn't get parallelRun metadata for the parallel task of type: %s, module: %s, description: %s, from queue %s", t.GetType(), hm.ModuleName, hm.EventDescription, queue.Name)
 					} else {
-						// cancel group task context
-						hm.GroupMetadata.CancelF()
+						// cancel parallel task context
+						hm.ParallelRunMetadata.CancelF()
 					}
 				}
 				logEntry.Debugf("Drained converge task of type: %s, module: %s, description: %s, from queue %s", t.GetType(), hm.ModuleName, hm.EventDescription, queue.Name)

--- a/pkg/addon-operator/queue_test.go
+++ b/pkg/addon-operator/queue_test.go
@@ -34,7 +34,7 @@ func Test_QueueHasPendingModuleRunTask(t *testing.T) {
 			},
 		},
 		{
-			name:   "GroupedModuleRun",
+			name:   "ParallelModuleRun",
 			result: true,
 			queue: func() *queue.TaskQueue {
 				q := queue.NewTasksQueue()
@@ -45,11 +45,11 @@ func Test_QueueHasPendingModuleRunTask(t *testing.T) {
 				Task = &sh_task.BaseTask{Type: task.ModuleRun, Id: "unknown"}
 				q.AddLast(Task.WithMetadata(task.HookMetadata{ModuleName: "unknown"}))
 
-				Task = &sh_task.BaseTask{Type: task.GroupedModuleRun, Id: "test"}
-				groupMetadata := &task.GroupMetadata{}
-				groupMetadata.SetModuleMetadata("test", task.GroupedModuleMetadata{})
-				groupMetadata.SetModuleMetadata("ne_test", task.GroupedModuleMetadata{})
-				q.AddLast(Task.WithMetadata(task.HookMetadata{GroupMetadata: groupMetadata}))
+				Task = &sh_task.BaseTask{Type: task.ParallelModuleRun, Id: "test"}
+				parallelRunMetadata := &task.ParallelRunMetadata{}
+				parallelRunMetadata.SetModuleMetadata("test", task.ParallelRunModuleMetadata{})
+				parallelRunMetadata.SetModuleMetadata("ne_test", task.ParallelRunModuleMetadata{})
+				q.AddLast(Task.WithMetadata(task.HookMetadata{ParallelRunMetadata: parallelRunMetadata}))
 				return q
 			},
 		},
@@ -396,7 +396,7 @@ func Test_RemoveCurrentConvergeTasks(t *testing.T) {
 					{Type: task.ModuleRun, Id: "3", Metadata: task.HookMetadata{IsReloadAll: true}},
 				},
 				{
-					{Type: task.GroupedModuleRun, Id: "1", Metadata: task.HookMetadata{IsReloadAll: true}},
+					{Type: task.ParallelModuleRun, Id: "1", Metadata: task.HookMetadata{IsReloadAll: true}},
 					{Type: task.ModuleDelete, Id: "4"},
 					{Type: task.ModuleDelete, Id: "5"},
 					{Type: task.ModuleRun, Id: "6", Metadata: task.HookMetadata{IsReloadAll: true}},

--- a/pkg/addon-operator/queue_test.go
+++ b/pkg/addon-operator/queue_test.go
@@ -34,6 +34,26 @@ func Test_QueueHasPendingModuleRunTask(t *testing.T) {
 			},
 		},
 		{
+			name:   "GroupedModuleRun",
+			result: true,
+			queue: func() *queue.TaskQueue {
+				q := queue.NewTasksQueue()
+
+				Task := &sh_task.BaseTask{Type: task.ModuleRun, Id: "unknown"}
+				q.AddLast(Task.WithMetadata(task.HookMetadata{ModuleName: "unknown"}))
+
+				Task = &sh_task.BaseTask{Type: task.ModuleRun, Id: "unknown"}
+				q.AddLast(Task.WithMetadata(task.HookMetadata{ModuleName: "unknown"}))
+
+				Task = &sh_task.BaseTask{Type: task.GroupedModuleRun, Id: "test"}
+				groupMetadata := &task.GroupMetadata{}
+				groupMetadata.SetModuleMetadata("test", task.GroupedModuleMetadata{})
+				groupMetadata.SetModuleMetadata("ne_test", task.GroupedModuleMetadata{})
+				q.AddLast(Task.WithMetadata(task.HookMetadata{GroupMetadata: groupMetadata}))
+				return q
+			},
+		},
+		{
 			name:   "First task",
 			result: false,
 			queue: func() *queue.TaskQueue {
@@ -274,6 +294,177 @@ func Test_ModulesWithPendingModuleRun(t *testing.T) {
 }
 
 func Test_RemoveCurrentConvergeTasks(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialTasks  [][]sh_task.BaseTask
+		expectTasks   [][]sh_task.BaseTask
+		expectRemoved bool
+	}{
+		{
+			name: "No Converge tasks",
+			initialTasks: [][]sh_task.BaseTask{
+				{
+					{Type: task.ModuleHookRun, Id: "5"},
+					{Type: task.GlobalHookRun, Id: "6"},
+				},
+				{
+					{Type: task.ModuleHookRun, Id: "7"},
+					{Type: task.GlobalHookRun, Id: "8"},
+				},
+				{
+					{Type: task.ConvergeModules, Id: "1"},
+					{Type: task.ModuleHookRun, Id: "2"},
+					{Type: task.GlobalHookRun, Id: "3"},
+				},
+			},
+			expectTasks: [][]sh_task.BaseTask{
+				{
+					{Type: task.ModuleHookRun, Id: "5"},
+					{Type: task.GlobalHookRun, Id: "6"},
+				},
+				{
+					{Type: task.ModuleHookRun, Id: "7"},
+					{Type: task.GlobalHookRun, Id: "8"},
+				},
+				{
+					{Type: task.ModuleHookRun, Id: "2"},
+					{Type: task.GlobalHookRun, Id: "3"},
+				},
+			},
+			expectRemoved: true,
+		},
+		{
+			name: "No Converge in progress, preceding tasks present",
+			initialTasks: [][]sh_task.BaseTask{
+				{
+					{Type: task.ModuleHookRun, Id: "5"},
+					{Type: task.GlobalHookRun, Id: "6"},
+				},
+				{
+					{Type: task.ModuleHookRun, Id: "7"},
+					{Type: task.GlobalHookRun, Id: "8"},
+				},
+				{
+					{Type: task.ConvergeModules, Id: "1"},
+					{Type: task.ConvergeModules, Id: "2"},
+					{Type: task.ModuleHookRun, Id: "3"},
+					{Type: task.GlobalHookRun, Id: "4"},
+				},
+			},
+			expectTasks: [][]sh_task.BaseTask{
+				{
+					{Type: task.ModuleHookRun, Id: "5"},
+					{Type: task.GlobalHookRun, Id: "6"},
+				},
+				{
+					{Type: task.ModuleHookRun, Id: "7"},
+					{Type: task.GlobalHookRun, Id: "8"},
+				},
+				{
+					{Type: task.ConvergeModules, Id: "2"},
+					{Type: task.ModuleHookRun, Id: "3"},
+					{Type: task.GlobalHookRun, Id: "4"},
+				},
+			},
+			expectRemoved: true,
+		},
+		{
+			name: "No ConvergeModules",
+			initialTasks: [][]sh_task.BaseTask{
+				{
+					{Type: task.ModuleRun, Id: "3"},
+				},
+				{},
+				{},
+			},
+			expectTasks: [][]sh_task.BaseTask{
+				{
+					{Type: task.ModuleRun, Id: "3"},
+				},
+				{},
+				{},
+			},
+			expectRemoved: false,
+		},
+		{
+			name: "Converge in progress",
+			initialTasks: [][]sh_task.BaseTask{
+				{
+					{Type: task.ModuleRun, Id: "2", Metadata: task.HookMetadata{IsReloadAll: true}},
+				},
+				{
+					{Type: task.ModuleRun, Id: "3", Metadata: task.HookMetadata{IsReloadAll: true}},
+				},
+				{
+					{Type: task.GroupedModuleRun, Id: "1", Metadata: task.HookMetadata{IsReloadAll: true}},
+					{Type: task.ModuleDelete, Id: "4"},
+					{Type: task.ModuleDelete, Id: "5"},
+					{Type: task.ModuleRun, Id: "6", Metadata: task.HookMetadata{IsReloadAll: true}},
+					{Type: task.ModuleRun, Id: "7", Metadata: task.HookMetadata{IsReloadAll: true}},
+					{Type: task.ModuleRun, Id: "8", Metadata: task.HookMetadata{IsReloadAll: true}},
+					{Type: task.ConvergeModules, Id: "9"},
+					{Type: task.ConvergeModules, Id: "10"},
+					{Type: task.ModuleRun, Id: "11"},
+					{Type: task.GlobalHookRun, Id: "12"},
+				},
+			},
+			expectTasks: [][]sh_task.BaseTask{
+				{},
+				{},
+				{
+					{Type: task.ConvergeModules, Id: "10"},
+					{Type: task.ModuleRun, Id: "11"},
+					{Type: task.GlobalHookRun, Id: "12"},
+				},
+			},
+			expectRemoved: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queues := make([]*queue.TaskQueue, 0, len(tt.initialTasks))
+			for _, tasks := range tt.initialTasks {
+				// Fill queue from the test case.
+				q := queue.NewTasksQueue()
+				queues = append(queues, q)
+				//nolint:govet
+				for _, tsk := range tasks {
+					tmpTsk := tsk
+					// Set metadata to prevent "possible bug" errors.
+					if tmpTsk.Metadata == nil {
+						tmpTsk.Metadata = task.HookMetadata{}
+					}
+					q.AddLast(&tmpTsk)
+				}
+				require.Equal(t, len(tasks), q.Length(), "Should add all tasks to the queue.")
+			}
+
+			// Try to clean the queue.
+			removed := RemoveCurrentConvergeTasks(queues, map[string]string{})
+
+			// Check result.
+			if tt.expectRemoved {
+				require.True(t, removed, "Should remove tasks from the queue")
+			} else {
+				require.False(t, removed, "Should not remove tasks from the queue")
+			}
+
+			for i, tasks := range tt.expectTasks {
+				// Check tasks in queue after remove.
+				require.Equal(t, len(tasks), queues[i].Length(), "length of queue %d should match length of expected tasks", i)
+				j := 0
+				queues[i].Iterate(func(tsk sh_task.Task) {
+					require.Equal(t, tt.expectTasks[i][j].Id, tsk.GetId(), "ID should match for task %d %+v", j, tsk)
+					require.Equal(t, tt.expectTasks[i][j].Type, tsk.GetType(), "Type should match for task %d %+v", j, tsk)
+					j++
+				})
+			}
+		})
+	}
+}
+
+func Test_RemoveCurrentConvergeTasksFromId(t *testing.T) {
 	const currentTaskID = "1"
 	tests := []struct {
 		name          string
@@ -312,7 +503,7 @@ func Test_RemoveCurrentConvergeTasks(t *testing.T) {
 			expectRemoved: true,
 		},
 		{
-			name: "Single adjacent ConvergeModules task with more Converge tasks",
+			name: "Single adjacent ConvergeModules",
 			initialTasks: []sh_task.BaseTask{
 				{Type: task.ConvergeModules, Id: currentTaskID},
 				{Type: task.ConvergeModules, Id: "2"},
@@ -373,7 +564,7 @@ func Test_RemoveCurrentConvergeTasks(t *testing.T) {
 			require.Equal(t, len(tt.initialTasks), q.Length(), "Should add all tasks to the queue.")
 
 			// Try to clean the queue.
-			removed := RemoveCurrentConvergeTasks(q, currentTaskID, map[string]string{})
+			removed := RemoveCurrentConvergeTasksFromId(q, currentTaskID, map[string]string{})
 
 			// Check result.
 			if tt.expectRemoved {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -51,10 +51,10 @@ var (
 	// CRDsFilters defines filters for CRD files, example `doc-,_`
 	CRDsFilters = "doc-,_"
 
-	// NumberOfGroupQueues defines the number of precreated group queues for parallel execution
-	NumberOfGroupQueues   = 10
-	GroupQueuePrefix      = "group_queue"
-	GroupQueueNamePattern = GroupQueuePrefix + "_%d"
+	// NumberOfParallelQueues defines the number of precreated parallel queues for parallel execution
+	NumberOfParallelQueues   = 10
+	ParallelQueuePrefix      = "parallel_queue"
+	ParallelQueueNamePattern = ParallelQueuePrefix + "_%d"
 )
 
 const (

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -50,6 +50,11 @@ var (
 	ExtraLabels = "heritage=addon-operator"
 	// CRDsFilters defines filters for CRD files, example `doc-,_`
 	CRDsFilters = "doc-,_"
+
+	// NumberOfGroupQueues defines the number of precreated group queues for parallel execution
+	NumberOfGroupQueues   = 10
+	GroupQueuePrefix      = "group_queue"
+	GroupQueueNamePattern = GroupQueuePrefix + "_%d"
 )
 
 const (

--- a/pkg/module_manager/models/modules/synchronization_state.go
+++ b/pkg/module_manager/models/modules/synchronization_state.go
@@ -49,14 +49,16 @@ func (s *SynchronizationState) HasQueued() bool {
 	return queued
 }
 
-// IsComplete returns true if all states are in done status.
-func (s *SynchronizationState) IsComplete() bool {
+// IsCompleted returns true if all states are in done status.
+func (s *SynchronizationState) IsCompleted() bool {
 	s.m.RLock()
 	defer s.m.RUnlock()
 	done := true
 	for _, state := range s.state {
 		if !state.Done {
 			done = false
+			log.Debugf("Synchronization isn't done for %s/%s", state.HookName, state.BindingName)
+			break
 		}
 	}
 	return done
@@ -86,6 +88,7 @@ func (s *SynchronizationState) DoneForBinding(id string) {
 		state = &kubernetesBindingSynchronizationState{}
 		s.state[id] = state
 	}
+	log.Debugf("Synchronization done for %s/%s", state.HookName, state.BindingName)
 	state.Done = true
 }
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -31,6 +31,7 @@ import (
 	kube_config_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/kube_config"
 	script_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/script_enabled"
 	static_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/static"
+	"github.com/flant/addon-operator/pkg/module_manager/scheduler/node"
 	"github.com/flant/addon-operator/pkg/task"
 	"github.com/flant/addon-operator/pkg/utils"
 	. "github.com/flant/shell-operator/pkg/hook/binding_context"
@@ -49,6 +50,8 @@ import (
 type ModulesState struct {
 	// All enabled modules.
 	AllEnabledModules []string
+	// All enabled modules grouped by order.
+	AllEnabledModulesByOrder map[node.NodeWeight][]string
 	// Modules that should be deleted.
 	ModulesToDisable []string
 	// Modules that was disabled and now are enabled.
@@ -417,7 +420,7 @@ func (mm *ModuleManager) RefreshEnabledState(logLabels map[string]string) (*Modu
 	})
 	logEntry := log.WithFields(utils.LabelsToLogFields(refreshLogLabels))
 
-	enabledModules, modulesDiff, err := mm.moduleScheduler.GetGraphState(refreshLogLabels)
+	enabledModules, enabledModulesByOrder, modulesDiff, err := mm.moduleScheduler.GetGraphState(refreshLogLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -459,9 +462,10 @@ func (mm *ModuleManager) RefreshEnabledState(logLabels map[string]string) (*Modu
 
 	// Return lists for ConvergeModules task.
 	return &ModulesState{
-		AllEnabledModules: enabledModules,
-		ModulesToDisable:  modulesToDisable,
-		ModulesToEnable:   modulesToEnable,
+		AllEnabledModules:        enabledModules,
+		AllEnabledModulesByOrder: enabledModulesByOrder,
+		ModulesToDisable:         modulesToDisable,
+		ModulesToEnable:          modulesToEnable,
 	}, nil
 }
 

--- a/pkg/module_manager/scheduler/node/node.go
+++ b/pkg/module_manager/scheduler/node/node.go
@@ -32,6 +32,20 @@ type Node struct {
 	module    ModuleInterface
 }
 
+type NodeWeightRange []NodeWeight
+
+func (r NodeWeightRange) Len() int {
+	return len(r)
+}
+
+func (r NodeWeightRange) Less(i, j int) bool {
+	return r[i] < r[j]
+}
+
+func (r NodeWeightRange) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
 const (
 	ModuleType NodeType = "module"
 	WeightType NodeType = "weight"

--- a/pkg/module_manager/scheduler/scheduler.go
+++ b/pkg/module_manager/scheduler/scheduler.go
@@ -467,16 +467,14 @@ func (s *Scheduler) getEnabledModuleNamesByOrder(weights ...node.NodeWeight) (ma
 		if bfsErr != nil {
 			return nil, bfsErr
 		}
-		sort.Slice(enabledModules, func(i, j int) bool {
-			return enabledModules[i] < enabledModules[j]
-		})
+		sort.Strings(enabledModules)
 		if len(enabledModules) > 0 {
 			result[rootVertex.GetWeight()] = enabledModules
 		}
 
 	// get modules of specified weights
 	default:
-		sort.Slice(weights, func(i, j int) bool { return weights[i] < weights[j] })
+		sort.Sort(node.NodeWeightRange(weights))
 		for _, weight := range weights {
 			enabledModulesByOrder, err := s.getEnabledModuleNamesByOrder([]node.NodeWeight{weight}...)
 			if err != nil {
@@ -519,7 +517,7 @@ func (s *Scheduler) GetGraphState(logLabels map[string]string) ( /*enabled modul
 	}
 
 	if len(s.errList) > 0 {
-		return s.getEnabledModuleNames(), nil, nil, fmt.Errorf("couldn't recalculate graph: %s", strings.Join(s.errList, ","))
+		return nil, nil, nil, fmt.Errorf("couldn't recalculate graph: %s", strings.Join(s.errList, ","))
 	}
 
 	enabledModulesByOrder, err := s.getEnabledModuleNamesByOrder()

--- a/pkg/task/hook_metadata.go
+++ b/pkg/task/hook_metadata.go
@@ -9,8 +9,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/flant/shell-operator/pkg/hook/binding_context"
 	"github.com/flant/addon-operator/pkg/module_manager/scheduler/node"
+	"github.com/flant/shell-operator/pkg/hook/binding_context"
 	"github.com/flant/shell-operator/pkg/hook/task_metadata"
 	"github.com/flant/shell-operator/pkg/hook/types"
 	"github.com/flant/shell-operator/pkg/task"
@@ -18,14 +18,14 @@ import (
 
 // HookMetadata is a metadata for addon-operator tasks
 type HookMetadata struct {
-	EventDescription string // event name for informative queue dump
-	HookName         string
-	ModuleName       string
+	EventDescription    string // event name for informative queue dump
+	HookName            string
+	ModuleName          string
 	ParallelRunMetadata *ParallelRunMetadata
-	Binding          string // binding name from configuration
-	BindingType      types.BindingType
-	BindingContext   []binding_context.BindingContext
-	AllowFailure     bool // Task considered as 'ok' if hook failed. False by default. Can be true for some schedule hooks.
+	Binding             string // binding name from configuration
+	BindingType         types.BindingType
+	BindingContext      []binding_context.BindingContext
+	AllowFailure        bool // Task considered as 'ok' if hook failed. False by default. Can be true for some schedule hooks.
 
 	DoModuleStartup bool // Execute onStartup and kubernetes@Synchronization hooks for module
 	IsReloadAll     bool // ModuleRun task is a part of 'Reload all modules' process.

--- a/pkg/task/hook_metadata.go
+++ b/pkg/task/hook_metadata.go
@@ -21,7 +21,7 @@ type HookMetadata struct {
 	EventDescription string // event name for informative queue dump
 	HookName         string
 	ModuleName       string
-	GroupMetadata    *GroupMetadata
+	ParallelRunMetadata *ParallelRunMetadata
 	Binding          string // binding name from configuration
 	BindingType      types.BindingType
 	BindingContext   []binding_context.BindingContext
@@ -41,55 +41,55 @@ type HookMetadata struct {
 	ExecuteOnSynchronization bool     // A flag to skip hook execution in Synchronization tasks.
 }
 
-// GroupMetadata is metadata for a group task
-type GroupMetadata struct {
+// ParallelRunMetadata is metadata for a parallel task
+type ParallelRunMetadata struct {
 	// the order the modules are grouped by
 	Order node.NodeWeight
-	// channelId of the groupedTaskChannel to communicate between grouped ModuleRun and GroupedModuleRun tasks
+	// channelId of the parallelTaskChannel to communicate between parallel ModuleRun and ParallelModuleRun tasks
 	ChannelId string
-	// context with cancel to stop GroupedModuleRun task
+	// context with cancel to stop ParallelModuleRun task
 	Context context.Context
 	CancelF func()
 
-	// map of modules, taking part in a group run
+	// map of modules, taking part in a parallel run
 	l       sync.Mutex
-	modules map[string]GroupedModuleMetadata
+	modules map[string]ParallelRunModuleMetadata
 }
 
-// GroupedModuleMetadata is metadata for a grouped module
-type GroupedModuleMetadata struct {
+// ParallelRunModuleMetadata is metadata for a parallel module
+type ParallelRunModuleMetadata struct {
 	DoModuleStartup bool
 }
 
-func (gm *GroupMetadata) GetModulesMetadata() map[string]GroupedModuleMetadata {
-	gm.l.Lock()
-	defer gm.l.Unlock()
-	return gm.modules
+func (pm *ParallelRunMetadata) GetModulesMetadata() map[string]ParallelRunModuleMetadata {
+	pm.l.Lock()
+	defer pm.l.Unlock()
+	return pm.modules
 }
 
-func (gm *GroupMetadata) SetModuleMetadata(moduleName string, metadata GroupedModuleMetadata) {
-	if gm.modules == nil {
-		gm.modules = make(map[string]GroupedModuleMetadata)
+func (pm *ParallelRunMetadata) SetModuleMetadata(moduleName string, metadata ParallelRunModuleMetadata) {
+	if pm.modules == nil {
+		pm.modules = make(map[string]ParallelRunModuleMetadata)
 	}
-	gm.l.Lock()
-	gm.modules[moduleName] = metadata
-	gm.l.Unlock()
+	pm.l.Lock()
+	pm.modules[moduleName] = metadata
+	pm.l.Unlock()
 }
 
-func (gm *GroupMetadata) DeleteModuleMetadata(moduleName string) {
-	if gm.modules == nil {
+func (pm *ParallelRunMetadata) DeleteModuleMetadata(moduleName string) {
+	if pm.modules == nil {
 		return
 	}
-	gm.l.Lock()
-	delete(gm.modules, moduleName)
-	gm.l.Unlock()
+	pm.l.Lock()
+	delete(pm.modules, moduleName)
+	pm.l.Unlock()
 }
 
-func (gm *GroupMetadata) ListModules() []string {
-	gm.l.Lock()
-	defer gm.l.Unlock()
-	result := make([]string, 0, len(gm.modules))
-	for module := range gm.modules {
+func (pm *ParallelRunMetadata) ListModules() []string {
+	pm.l.Lock()
+	defer pm.l.Unlock()
+	result := make([]string, 0, len(pm.modules))
+	for module := range pm.modules {
 		result = append(result, module)
 	}
 	return result

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -14,8 +14,8 @@ const (
 	ModuleDelete task.TaskType = "ModuleDelete"
 	// ModuleRun runs beforeHelm/helm upgrade/afterHelm sequence.
 	ModuleRun task.TaskType = "ModuleRun"
-	// GroupedModuleRun runs beforeHelm/helm upgrade/afterHelm sequence for a group of modules.
-	GroupedModuleRun task.TaskType = "GroupedModuleRun"
+	// ParallelModuleRun runs beforeHelm/helm upgrade/afterHelm sequence for a bunch of modules in parallel.
+	ParallelModuleRun task.TaskType = "ParallelModuleRun"
 	// ModulePurge - delete unknown helm release (no module in ModulesDir)
 	ModulePurge task.TaskType = "ModulePurge"
 	// ModuleEnsureCRDs runs ensureCRDs task for enabled module

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -14,6 +14,8 @@ const (
 	ModuleDelete task.TaskType = "ModuleDelete"
 	// ModuleRun runs beforeHelm/helm upgrade/afterHelm sequence.
 	ModuleRun task.TaskType = "ModuleRun"
+	// GroupedModuleRun runs beforeHelm/helm upgrade/afterHelm sequence for a group of modules.
+	GroupedModuleRun task.TaskType = "GroupedModuleRun"
 	// ModulePurge - delete unknown helm release (no module in ModulesDir)
 	ModulePurge task.TaskType = "ModulePurge"
 	// ModuleEnsureCRDs runs ensureCRDs task for enabled module


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

`ModuleRun` tasks and corresponding `ModuleHookRun` tasks for modules of the same order (weight) are executed `in parallel` in `parallel` queues. There are 10 `parallel` queues by default in the operator's queue set.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
This pr adds new type of tasks - `ParallelModuleRun`. A task of this type represents a group of smaller tasks with the same order/weight of `ModuleRun` and `ModuleHookRun` types. These subordinate tasks are executed in parallel pre-created named `parallel_queue_x` queues and all the results and errors are propagated back to the  corresponding `ParallelModuleRun` task that updates its status accordingly. 
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
