### PR TITLE
reinit helm3lib action config on global hook module reload

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flant/addon-operator/pkg/addon-operator/converge"
 	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm"
+	"github.com/flant/addon-operator/pkg/helm/helm3lib"
 	"github.com/flant/addon-operator/pkg/helm_resources_manager"
 	hookTypes "github.com/flant/addon-operator/pkg/hook/types"
 	"github.com/flant/addon-operator/pkg/kube_config_manager"
@@ -2023,6 +2024,16 @@ func (op *AddonOperator) HandleGlobalHookRun(t sh_task.Task, labels map[string]s
 			}
 			// Queue ReloadAllModules task
 			if reloadAll {
+				// if helm3lib is in use - reinit helm action configuration to update helm capabilities (newly available apiVersions and resoruce kinds)
+				if op.Helm.ClientType == helm.Helm3Lib {
+					if err := helm3lib.ReinitActionConfig(); err != nil {
+						logEntry.Errorf("Couldn't reinitialize helm3lib action configuration: %s", err)
+						t.UpdateFailureMessage(err.Error())
+						t.WithQueuedAt(time.Now())
+						res.Status = queue.Fail
+						return res
+					}
+				}
 				// Stop and remove all resource monitors to prevent excessive ModuleRun tasks
 				op.HelmResourcesManager.StopMonitors()
 				logLabels := t.GetLogLabels()

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -11,6 +11,7 @@ import (
 
 type ClientFactory struct {
 	NewClientFn func(logLabels ...map[string]string) client.HelmClient
+	ClientType  ClientType
 }
 
 func (f *ClientFactory) NewClient(logLabels ...map[string]string) client.HelmClient {
@@ -31,6 +32,7 @@ func InitHelmClientFactory() (*ClientFactory, error) {
 	switch helmVersion {
 	case Helm3Lib:
 		log.Info("Helm3Lib detected. Use builtin Helm.")
+		factory.ClientType = Helm3Lib
 		factory.NewClientFn = helm3lib.NewClient
 		err = helm3lib.Init(&helm3lib.Options{
 			Namespace:  app.Namespace,
@@ -41,6 +43,7 @@ func InitHelmClientFactory() (*ClientFactory, error) {
 	case Helm3:
 		log.Infof("Helm 3 detected (path is '%s')", helm3.Helm3Path)
 		// Use helm3 client.
+		factory.ClientType = Helm3
 		factory.NewClientFn = helm3.NewClient
 		err = helm3.Init(&helm3.Helm3Options{
 			Namespace:  app.Namespace,

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -37,6 +37,16 @@ func Init(opts *Options) error {
 	return hc.initAndVersion()
 }
 
+// ReinitActionConfig reinitializes helm3 action configuration to update its list of capabilities
+func ReinitActionConfig() error {
+	hc := &LibClient{
+		LogEntry: log.WithField("operator.component", "helm3lib"),
+	}
+	log.Debug("Reinitialize Helm 3 lib action configuration")
+
+	return hc.actionConfigInit()
+}
+
 // LibClient use helm3 package as Go library.
 type LibClient struct {
 	LogEntry  *log.Entry


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
If helm3lib is in use, reinit its action configuration every time a global hook provokes reconverge of all modules, cause we need to refresh helm's client capabilities in case of such a global change like kubernetes version upgrade.

#### What this PR does / why we need it
We need it to keep helm's client capabilities list up-to-date.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
