### PR TITLE
fix: compare crd spec, labels and annotations before update

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,10 +5,10 @@ linters:
   enable:
   - asciicheck
   - bodyclose
+  - copyloopvar
   - depguard
   - dogsled
   - durationcheck
-  - exportloopref
   - gci
   - gochecknoinits
   - gocritic

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-openapi/validate v0.19.12
 	github.com/goccy/go-graphviz v0.1.3
 	github.com/gofrs/uuid/v5 v5.3.0
+	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/onsi/gomega v1.35.1
@@ -90,7 +91,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/pkg/addon-operator/ensure_crds.go
+++ b/pkg/addon-operator/ensure_crds.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"sync"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -220,8 +220,9 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *v1.CustomRe
 			crd.Spec.Conversion = existCRD.Spec.Conversion
 		}
 
-		if existCRD.GetObjectMeta().GetLabels()[LabelHeritage] == cp.crdExtraLabels[LabelHeritage] &&
-			reflect.DeepEqual(existCRD.Spec, crd.Spec) {
+		if cmp.Equal(existCRD.Spec, crd.Spec) &&
+			cmp.Equal(existCRD.GetLabels(), crd.GetLabels()) &&
+			cmp.Equal(existCRD.GetAnnotations(), crd.GetAnnotations()) {
 			return nil
 		}
 

--- a/pkg/addon-operator/operator_test.go
+++ b/pkg/addon-operator/operator_test.go
@@ -8,12 +8,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8types "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 
 	"github.com/flant/addon-operator/pkg/addon-operator/converge"
 	mockhelm "github.com/flant/addon-operator/pkg/helm/test/mock"

--- a/pkg/addon-operator/operator_test.go
+++ b/pkg/addon-operator/operator_test.go
@@ -8,13 +8,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/deckhouse/deckhouse/pkg/log"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8types "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
-
-	"github.com/deckhouse/deckhouse/pkg/log"
 
 	"github.com/flant/addon-operator/pkg/addon-operator/converge"
 	mockhelm "github.com/flant/addon-operator/pkg/helm/test/mock"

--- a/pkg/utils/values_test.go
+++ b/pkg/utils/values_test.go
@@ -2,10 +2,10 @@ package utils
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -40,7 +40,7 @@ func Test_MergeValues(t *testing.T) {
 		t.Run(expectation.testName, func(t *testing.T) {
 			values := MergeValues(expectation.values1, expectation.values2)
 
-			if !reflect.DeepEqual(expectation.expectedValues, values) {
+			if !cmp.Equal(expectation.expectedValues, values) {
 				t.Errorf("\n[EXPECTED]: %#v\n[GOT]: %#v", expectation.expectedValues, values)
 			}
 		})


### PR DESCRIPTION
#### Overview

Before installing crd into a cluster, we need to compare it with the existing one. Previously, we only compared spec and one of the labels. Now we will compare spec, the full set of labels and annotations.

#### What this PR does / why we need it

In order to backup the CRD cluster, we will install certain labels on the necessary resources. To be able to install labels, we need to check their presence in the cluster. So as not to delete them during the next update.

