### PR TITLE
[scheduler] add topological extender type

### DIFF
--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -30,7 +30,6 @@ import (
 	kube_config_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/kube_config"
 	script_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/script_enabled"
 	static_extender "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/static"
-	"github.com/flant/addon-operator/pkg/module_manager/scheduler/node"
 	"github.com/flant/addon-operator/pkg/task"
 	"github.com/flant/addon-operator/pkg/utils"
 	. "github.com/flant/shell-operator/pkg/hook/binding_context"
@@ -55,7 +54,7 @@ type ModulesState struct {
 	// All enabled modules.
 	AllEnabledModules []string
 	// All enabled modules grouped by order.
-	AllEnabledModulesByOrder map[node.NodeWeight][]string
+	AllEnabledModulesByOrder [][]string
 	// Modules that should be deleted.
 	ModulesToDisable []string
 	// Modules that was disabled and now are enabled.
@@ -881,6 +880,7 @@ func (mm *ModuleManager) RecalculateGraph(logLabels map[string]string) bool {
 			EventType:  events.ModuleStateChanged,
 		})
 	}
+
 	return stateChanged
 }
 
@@ -893,6 +893,7 @@ func (mm *ModuleManager) GlobalSynchronizationNeeded() bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/pkg/module_manager/scheduler/extenders/extenders.go
+++ b/pkg/module_manager/scheduler/extenders/extenders.go
@@ -26,8 +26,13 @@ type NotificationExtender interface {
 	SetNotifyChannel(context.Context, chan ExtenderEvent)
 }
 
+type TopologicalExtender interface {
+	// GetTopologicalHints returns the list of vertices that should be connected to the specified vertex
+	GetTopologicalHints(string) []string
+}
+
 // Hail to enabled scripts
-type ResettableExtender interface {
-	// Reset resets the extender's cache
-	Reset()
+type StatefulExtender interface {
+	// SetModulesStateHelper sets a helper function to get the list of enabled modules according to the latest vertex state buffer
+	SetModulesStateHelper(func() []string)
 }

--- a/pkg/module_manager/scheduler/extenders/mock/extenders_mock.go
+++ b/pkg/module_manager/scheduler/extenders/mock/extenders_mock.go
@@ -100,3 +100,54 @@ func (f *TerminatorThree) Filter(_ string, _ map[string]string) (*bool, error) {
 func (f *TerminatorThree) IsTerminator() bool {
 	return true
 }
+
+type TopologicalOne struct{}
+
+func (f *TopologicalOne) Name() extenders.ExtenderName {
+	return extenders.ExtenderName("TopologicalOne")
+}
+
+func (f *TopologicalOne) Filter(_ string, _ map[string]string) (*bool, error) {
+	return nil, nil
+}
+
+func (f *TopologicalOne) IsTerminator() bool {
+	return true
+}
+
+func (f *TopologicalOne) GetTopologicalHints(moduleName string) []string {
+	switch moduleName {
+	case "echo":
+		return []string{"prometheus", "cert-manager"}
+	case "prometheus":
+		return []string{"prometheus-crd"}
+	case "foobar":
+		return []string{"foo", "bar"}
+	case "operator-trivy":
+		return []string{"istio", "admission-policy-engine"}
+	}
+
+	return nil
+}
+
+type TopologicalTwo struct{}
+
+func (f *TopologicalTwo) Name() extenders.ExtenderName {
+	return extenders.ExtenderName("TopologicalTwo")
+}
+
+func (f *TopologicalTwo) Filter(_ string, _ map[string]string) (*bool, error) {
+	return nil, nil
+}
+
+func (f *TopologicalTwo) IsTerminator() bool {
+	return true
+}
+
+func (f *TopologicalTwo) GetTopologicalHints(moduleName string) []string {
+	if moduleName == "my-module" {
+		return []string{"unknown-module"}
+	}
+
+	return nil
+}

--- a/pkg/module_manager/scheduler/extenders/script_enabled/script_test.go
+++ b/pkg/module_manager/scheduler/extenders/script_enabled/script_test.go
@@ -63,10 +63,19 @@ func TestExtender(t *testing.T) {
 		},
 	}
 
+	sharedEnabledModules := make([]string, 0)
+	helper := func() []string {
+		return sharedEnabledModules
+	}
+	e.SetModulesStateHelper(helper)
+
 	logLabels := map[string]string{"source": "TestExtender"}
 	for _, m := range basicModules {
 		e.AddBasicModule(m)
 		enabled, err := e.Filter(m.Name, logLabels)
+		if enabled == nil || (enabled != nil && *enabled) {
+			sharedEnabledModules = append(sharedEnabledModules, m.Name)
+		}
 		switch m.GetName() {
 		case "foo-bar":
 			assert.Equal(t, true, *enabled)
@@ -87,7 +96,7 @@ func TestExtender(t *testing.T) {
 	}
 
 	expected := []string{"ingress-nginx", "cert-manager", "foo-bar"}
-	assert.Equal(t, expected, e.enabledModules)
+	assert.Equal(t, expected, e.GetEnabledModules())
 
 	err = os.RemoveAll(tmp)
 	assert.NoError(t, err)

--- a/pkg/module_manager/scheduler/node/node.go
+++ b/pkg/module_manager/scheduler/node/node.go
@@ -32,23 +32,10 @@ type Node struct {
 	module    ModuleInterface
 }
 
-type NodeWeightRange []NodeWeight
-
-func (r NodeWeightRange) Len() int {
-	return len(r)
-}
-
-func (r NodeWeightRange) Less(i, j int) bool {
-	return r[i] < r[j]
-}
-
-func (r NodeWeightRange) Swap(i, j int) {
-	r[i], r[j] = r[j], r[i]
-}
-
 const (
-	ModuleType NodeType = "module"
-	WeightType NodeType = "weight"
+	ModuleType    NodeType = "module"
+	WeightType    NodeType = "weight"
+	TypeAttribute string   = "type"
 )
 
 func NewNode() *Node {

--- a/pkg/task/hook_metadata.go
+++ b/pkg/task/hook_metadata.go
@@ -10,7 +10,6 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules"
-	"github.com/flant/addon-operator/pkg/module_manager/scheduler/node"
 	bindingcontext "github.com/flant/shell-operator/pkg/hook/binding_context"
 	"github.com/flant/shell-operator/pkg/hook/task_metadata"
 	"github.com/flant/shell-operator/pkg/hook/types"
@@ -44,8 +43,6 @@ type HookMetadata struct {
 
 // ParallelRunMetadata is metadata for a parallel task
 type ParallelRunMetadata struct {
-	// the order the modules are grouped by
-	Order node.NodeWeight
 	// channelId of the parallelTaskChannel to communicate between parallel ModuleRun and ParallelModuleRun tasks
 	ChannelId string
 	// context with cancel to stop ParallelModuleRun task


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

Enhances the scheduler to support an additional type of extenders which can alter the graph's structure with topological hints, implementing tighter dependency (comparing to weight-based dependency) between vertices/modules.

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Provides two new extender types: 
Stateful extender (instead of Ressetable extender) is a type of extenders that requires to have the current state of vertices (during the calculation) in order to make a decision if a module has to be enabled/disabled (for example, script enabled extender works this way. This state is shared among all Stateful extenders meaning that two or more extenders are able to follow the changes other extenders apply when filtering.

Topological extender, provides additional connections between vertices by means of `GetTopologicalHints` method. These hints are used when the graph is being built and could represent additional dependencies between vertices (modules). If a module has a dependency from another module, this module's weight has no effect anymore and the module's run during the converge process takes place right after the latest dependency run.

Some other minor changes like using custom BFS method for traversing the graph, and so on.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
