### PR TITLE
refresh states of disabled modules on first converge

### DIFF
--- a/pkg/addon-operator/operator.go
+++ b/pkg/addon-operator/operator.go
@@ -821,6 +821,20 @@ func (op *AddonOperator) HandleConvergeModules(t sh_task.Task, logLabels map[str
 			// Set ModulesToEnable list to properly run onStartup hooks for first converge.
 			if !op.IsStartupConvergeDone() {
 				state.ModulesToEnable = state.AllEnabledModules
+				// send ModuleEvents for each disabled module on first converge to update dsabled modules' states (for the sake of disabled by <extender_name>)
+				enabledModules := make(map[string]struct{}, len(state.AllEnabledModules))
+				for _, enabledModule := range state.AllEnabledModules {
+					enabledModules[enabledModule] = struct{}{}
+				}
+
+				for _, moduleName := range op.ModuleManager.GetModuleNames() {
+					if _, enabled := enabledModules[moduleName]; !enabled {
+						op.ModuleManager.SendModuleEvent(events.ModuleEvent{
+							ModuleName: moduleName,
+							EventType:  events.ModuleDisabled,
+						})
+					}
+				}
 			}
 			tasks := op.CreateConvergeModulesTasks(state, t.GetLogLabels(), string(taskEvent))
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

Adds sending module events for all disabled modules when doing first converge. This way we can update modules' states and correctly reflect reasons why the modules were disabled.

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
