### PR TITLE
[shell-hooks] consider python vevn when running python scripts

### DIFF
--- a/pkg/module_manager/models/hooks/kind/shellhook.go
+++ b/pkg/module_manager/models/hooks/kind/shellhook.go
@@ -41,17 +41,12 @@ type ShellHook struct {
 	ScheduleConfig *HookScheduleConfig
 }
 
-// NewShellHook new hook, which runs via the OS interpreter like bash/python/etc
-func NewShellHook(name, path, pythonVenv, moduleName string, keepTemporaryHookFiles bool, logProxyHookJSON bool, logger *log.Logger) *ShellHook {
-	logger.Debug("Creating a new shell hook",
-		slog.String("module", moduleName),
-		slog.String("hookName", name),
-		slog.String("pythonVenv", pythonVenv),
-	)
+type ShellHookOption func(*ShellHook)
 
-	return &ShellHook{
+// NewShellHook new hook, which runs via the OS interpreter like bash/python/etc
+func NewShellHook(name, path, moduleName string, keepTemporaryHookFiles bool, logProxyHookJSON bool, logger *log.Logger, options ...ShellHookOption) *ShellHook {
+	sh := &ShellHook{
 		moduleName: moduleName,
-		pythonVenv: pythonVenv,
 		Hook: sh_hook.Hook{
 			Name:                   name,
 			Path:                   path,
@@ -60,6 +55,25 @@ func NewShellHook(name, path, pythonVenv, moduleName string, keepTemporaryHookFi
 			Logger:                 logger,
 		},
 		ScheduleConfig: &HookScheduleConfig{},
+	}
+
+	for _, opt := range options {
+		opt(sh)
+	}
+
+	logger.Debug("Created a new shell hook",
+		slog.String("module", sh.moduleName),
+		slog.String("hookName", sh.Name),
+		slog.String("path", sh.Path),
+		slog.String("pythonVenv", sh.pythonVenv),
+	)
+
+	return sh
+}
+
+func WithPythonVenv(pythonVenvPath string) ShellHookOption {
+	return func(sh *ShellHook) {
+		sh.pythonVenv = pythonVenvPath
 	}
 }
 

--- a/pkg/module_manager/models/hooks/kind/shellhook.go
+++ b/pkg/module_manager/models/hooks/kind/shellhook.go
@@ -24,19 +24,34 @@ import (
 	metricoperation "github.com/flant/shell-operator/pkg/metric_storage/operation"
 )
 
+const (
+	PythonVenvPath   = "hooks/venv"
+	PythonBinaryPath = "bin/python3"
+
+	pythonHomeEnv = "PYTHONHOME"
+)
+
 var _ gohook.HookConfigLoader = (*ShellHook)(nil)
 
 type ShellHook struct {
 	moduleName string
+	pythonVenv string
 	sh_hook.Hook
 
 	ScheduleConfig *HookScheduleConfig
 }
 
 // NewShellHook new hook, which runs via the OS interpreter like bash/python/etc
-func NewShellHook(name, path, moduleName string, keepTemporaryHookFiles bool, logProxyHookJSON bool, logger *log.Logger) *ShellHook {
+func NewShellHook(name, path, pythonVenv, moduleName string, keepTemporaryHookFiles bool, logProxyHookJSON bool, logger *log.Logger) *ShellHook {
+	logger.Debug("Creating a new shell hook",
+		slog.String("module", moduleName),
+		slog.String("hookName", name),
+		slog.String("pythonVenv", pythonVenv),
+	)
+
 	return &ShellHook{
 		moduleName: moduleName,
+		pythonVenv: pythonVenv,
 		Hook: sh_hook.Hook{
 			Name:                   name,
 			Path:                   path,
@@ -125,16 +140,21 @@ func (sh *ShellHook) Execute(configVersion string, bContext []bindingcontext.Bin
 	metricsPath := tmpFiles["METRICS_PATH"]
 	kubernetesPatchPath := tmpFiles["KUBERNETES_PATCH_PATH"]
 
-	envs := make([]string, 0)
-	envs = append(envs, os.Environ()...)
+	envs := os.Environ()
 	for envName, filePath := range tmpFiles {
 		envs = append(envs, fmt.Sprintf("%s=%s", envName, filePath))
+	}
+	command := sh.GetPath()
+	args := make([]string, 0)
+
+	if filepath.Ext(command) == ".py" {
+		sh.updateExecutorParamsForPython(&command, &envs, &args)
 	}
 
 	cmd := executor.NewExecutor(
 		"",
-		sh.GetPath(),
-		[]string{},
+		command,
+		args,
 		envs).
 		WithLogProxyHookJSON(shapp.LogProxyHookJSON).
 		WithLogProxyHookJSONKey(sh.LogProxyHookJSONKey).
@@ -175,14 +195,41 @@ func (sh *ShellHook) Execute(configVersion string, bContext []bindingcontext.Bin
 	return result, nil
 }
 
+// updateExecutorParamsForPython modifies command, env and args executor arguments to run a python script by
+// the python version supplied with the module. If the module has no python, the script is run by the global python
+// version and a warning is thrown.
+func (sh *ShellHook) updateExecutorParamsForPython(command *string, envs, args *[]string) {
+	sh.Hook.Logger.Debug("Updating hook's exec parameters",
+		slog.String("module", sh.moduleName),
+		slog.String("hookName", sh.Name),
+	)
+
+	if len(sh.pythonVenv) != 0 {
+		*envs = append(*envs, fmt.Sprintf("%s=%s", pythonHomeEnv, sh.pythonVenv))
+		*command = filepath.Join(sh.pythonVenv, PythonBinaryPath)
+		newArgs := make([]string, 1, len(*args)+1)
+		newArgs[0] = sh.Path
+		*args = append(newArgs, *args...)
+	} else {
+		sh.Hook.Logger.Warn("Module executes python hooks, but has no python virtual environment",
+			slog.String("module", sh.moduleName),
+			slog.String("hookName", sh.Name),
+		)
+	}
+}
+
 func (sh *ShellHook) getConfig() ([]byte, error) {
-	envs := make([]string, 0)
-	envs = append(envs, os.Environ()...)
+	envs := os.Environ()
+	command := sh.Path
 	args := []string{"--config"}
+
+	if filepath.Ext(command) == ".py" {
+		sh.updateExecutorParamsForPython(&command, &envs, &args)
+	}
 
 	cmd := executor.NewExecutor(
 		"",
-		sh.Path,
+		command,
 		args,
 		envs).
 		WithLogProxyHookJSON(shapp.LogProxyHookJSON).

--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -295,7 +295,8 @@ func (bm *BasicModule) searchModuleShellHooks() ([]*kind.ShellHook, error) {
 	)
 
 	for _, hookPath := range hooksRelativePaths {
-		var pythonVenvPath string
+		options := make([]kind.ShellHookOption, 0, 1)
+
 		if filepath.Ext(hookPath) == ".py" {
 			checkPythonEnv.Do(func() {
 				f, err := os.Stat(filepath.Join(bm.Path, kind.PythonVenvPath, kind.PythonBinaryPath))
@@ -305,7 +306,7 @@ func (bm *BasicModule) searchModuleShellHooks() ([]*kind.ShellHook, error) {
 					}
 				}
 			})
-			pythonVenvPath = discoveredPythonVenvPath
+			options = append(options, kind.WithPythonVenv(discoveredPythonVenvPath))
 		}
 
 		hookName, err := filepath.Rel(filepath.Dir(bm.Path), hookPath)
@@ -322,7 +323,7 @@ func (bm *BasicModule) searchModuleShellHooks() ([]*kind.ShellHook, error) {
 			bm.logger.Warn("get batch hook config", slog.String("hook_file_path", hookPath), log.Err(err))
 		}
 
-		shHook := kind.NewShellHook(hookName, hookPath, pythonVenvPath, bm.safeName(), bm.keepTemporaryHookFiles, shapp.LogProxyHookJSON, bm.logger.Named("shell-hook"))
+		shHook := kind.NewShellHook(hookName, hookPath, bm.safeName(), bm.keepTemporaryHookFiles, shapp.LogProxyHookJSON, bm.logger.Named("shell-hook"), options...)
 
 		hks = append(hks, shHook)
 	}

--- a/pkg/module_manager/models/modules/global.go
+++ b/pkg/module_manager/models/modules/global.go
@@ -548,7 +548,7 @@ func (gm *GlobalModule) searchGlobalShellHooks(hooksDir string) ([]*kind.ShellHo
 			}
 		}
 
-		globalHook := kind.NewShellHook(hookName, hookPath, "global", gm.keepTemporaryHookFiles, false, gm.logger.Named("shell-hook"))
+		globalHook := kind.NewShellHook(hookName, hookPath, "", "global", gm.keepTemporaryHookFiles, false, gm.logger.Named("shell-hook"))
 
 		hks = append(hks, globalHook)
 	}

--- a/pkg/module_manager/models/modules/global.go
+++ b/pkg/module_manager/models/modules/global.go
@@ -548,7 +548,7 @@ func (gm *GlobalModule) searchGlobalShellHooks(hooksDir string) ([]*kind.ShellHo
 			}
 		}
 
-		globalHook := kind.NewShellHook(hookName, hookPath, "", "global", gm.keepTemporaryHookFiles, false, gm.logger.Named("shell-hook"))
+		globalHook := kind.NewShellHook(hookName, hookPath, "global", gm.keepTemporaryHookFiles, false, gm.logger.Named("shell-hook"))
 
 		hks = append(hks, globalHook)
 	}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Updates running shellhooks logic in a way that allows running a module's python hooks (*.py) with a custom python version, located in the `/module_path/hooks/venv` directory.

If a module has python hooks, but doesn't provide custom python instance in the `/module_path/hooks/venv` directory`, the hooks are executed by the system python instance and a warning is thrown.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Closes https://github.com/deckhouse/deckhouse/issues/12311

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
