### PR TITLE
Use force while upgrade templates

### DIFF
--- a/pkg/helm/helm3/helm3.go
+++ b/pkg/helm/helm3/helm3.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
 	k8syaml "sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 
 	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/utils"
@@ -142,6 +143,7 @@ func (h *Helm3Client) UpgradeRelease(releaseName string, chart string, valuesPat
 	args := []string{
 		"upgrade", releaseName, chart,
 		"--install",
+		"--force",
 		"--skip-crds",
 		"--history-max", fmt.Sprintf("%d", Options.HistoryMax),
 		"--timeout", Options.Timeout.String(),

--- a/pkg/helm/helm3/helm3.go
+++ b/pkg/helm/helm3/helm3.go
@@ -9,9 +9,8 @@ import (
 	"strings"
 	"time"
 
-	k8syaml "sigs.k8s.io/yaml"
-
 	"github.com/deckhouse/deckhouse/pkg/log"
+	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/utils"

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -245,6 +245,7 @@ func (h *LibClient) upgradeRelease(releaseName string, chartName string, valuesP
 			instClient.PostRenderer = helmPostRenderer
 		}
 		instClient.SkipCRDs = true
+		instClient.Force = true
 		instClient.Timeout = options.Timeout
 		instClient.ReleaseName = releaseName
 		instClient.UseReleaseName = true

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deckhouse/deckhouse/pkg/log"
+	logContext "github.com/deckhouse/deckhouse/pkg/log/context"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -23,9 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
-
-	"github.com/deckhouse/deckhouse/pkg/log"
-	logContext "github.com/deckhouse/deckhouse/pkg/log/context"
 
 	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/helm/post_renderer"

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -250,7 +250,7 @@ func (h *LibClient) upgradeRelease(releaseName string, chartName string, valuesP
 		instClient.Timeout = options.Timeout
 		instClient.ReleaseName = releaseName
 		instClient.UseReleaseName = true
-		fmt.Println("INSTALL WITH FORCE", releaseName, instClient.Force)
+
 		_, err = instClient.Run(chart, resultValues)
 		return err
 	}
@@ -310,7 +310,6 @@ func (h *LibClient) upgradeRelease(releaseName string, chartName string, valuesP
 		}
 	}
 
-	fmt.Println("UPGRADE WITH FORCE", releaseName, upg.Force)
 	_, err = upg.Run(releaseName, chart, resultValues)
 	if err != nil {
 		return fmt.Errorf("helm upgrade failed: %s\n", err)

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -196,6 +196,7 @@ func (h *LibClient) upgradeRelease(releaseName string, chartName string, valuesP
 	}
 
 	upg.Install = true
+	upg.Force = true
 	upg.SkipCRDs = true
 	upg.MaxHistory = int(options.HistoryMax)
 	upg.Timeout = options.Timeout

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
-	logContext "github.com/deckhouse/deckhouse/pkg/log/context"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -25,6 +23,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	logContext "github.com/deckhouse/deckhouse/pkg/log/context"
 
 	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/helm/post_renderer"
@@ -249,7 +250,7 @@ func (h *LibClient) upgradeRelease(releaseName string, chartName string, valuesP
 		instClient.Timeout = options.Timeout
 		instClient.ReleaseName = releaseName
 		instClient.UseReleaseName = true
-
+		fmt.Println("INSTALL WITH FORCE", releaseName, instClient.Force)
 		_, err = instClient.Run(chart, resultValues)
 		return err
 	}
@@ -309,6 +310,7 @@ func (h *LibClient) upgradeRelease(releaseName string, chartName string, valuesP
 		}
 	}
 
+	fmt.Println("UPGRADE WITH FORCE", releaseName, upg.Force)
 	_, err = upg.Run(releaseName, chart, resultValues)
 	if err != nil {
 		return fmt.Errorf("helm upgrade failed: %s\n", err)

--- a/pkg/module_manager/environment_manager/mount.go
+++ b/pkg/module_manager/environment_manager/mount.go
@@ -2,6 +2,6 @@
 
 package environment_manager
 
-func MountFn(_ string, _ string, _ string, _ uintptr, _ string, recursiveMount bool) error {
+func MountFn(_ string, _ string, _ string, _ uintptr, _ string, _ bool) error {
 	return nil
 }

--- a/pkg/module_manager/models/modules/global.go
+++ b/pkg/module_manager/models/modules/global.go
@@ -356,6 +356,8 @@ func (gm *GlobalModule) SetEnabledModules(enabledModules []string) {
 		return
 	}
 
+	// keep apiVersions sorted to prevent helm rollout on each restart
+	sort.Strings(enabledModules)
 	data, _ := json.Marshal(enabledModules)
 	gm.valuesStorage.appendValuesPatch(utils.ValuesPatch{Operations: []*utils.ValuesPatchOperation{
 		{

--- a/pkg/module_manager/models/modules/global.go
+++ b/pkg/module_manager/models/modules/global.go
@@ -335,6 +335,8 @@ func (gm *GlobalModule) SetAvailableAPIVersions(apiVersions []string) {
 		return
 	}
 
+	// keep apiVersions sorted to prevent helm rollout on each restart
+	sort.Strings(apiVersions)
 	data, _ := json.Marshal(apiVersions)
 	gm.valuesStorage.appendValuesPatch(utils.ValuesPatch{Operations: []*utils.ValuesPatchOperation{
 		{

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -11,9 +11,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/gofrs/uuid/v5"
 	"github.com/kennygrant/sanitize"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 
 	"github.com/flant/addon-operator/pkg/helm"
 	"github.com/flant/addon-operator/pkg/helm/client"
@@ -335,7 +336,9 @@ func (hm *HelmModule) shouldRunHelmUpgrade(helmClient client.HelmClient, release
 	if len(absent) > 0 {
 		logEntry.Debug("helm release has absent resources: should run upgrade",
 			slog.String("release", releaseName),
-			slog.Int("count", len(absent)))
+			slog.Int("count", len(absent)),
+			slog.Any("manifests", absent),
+		)
 		return true, nil
 	}
 

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -337,7 +337,6 @@ func (hm *HelmModule) shouldRunHelmUpgrade(helmClient client.HelmClient, release
 		logEntry.Debug("helm release has absent resources: should run upgrade",
 			slog.String("release", releaseName),
 			slog.Int("count", len(absent)),
-			slog.Any("manifests", absent),
 		)
 		return true, nil
 	}

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -11,10 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/gofrs/uuid/v5"
 	"github.com/kennygrant/sanitize"
-
-	"github.com/deckhouse/deckhouse/pkg/log"
 
 	"github.com/flant/addon-operator/pkg/helm"
 	"github.com/flant/addon-operator/pkg/helm/client"


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview



#### What this PR does / why we need it

Use `force` update to replace resources instead of making three way merge. Module's templates is a source of truth and we have to keep objects clear, instead of merging with a cluster changes
Sort `enabledModules` and `apiVersion`. These values are used in charts, so they trigger release deploy every time, even values are not changed

#### Special notes for your reviewer

**BREAKING CHANGES**
Modules will not keep resource changes made manually in a cluster anymore.
