### PR TITLE
feat: improve error message for invalid module hook configuration

### DIFF
--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -479,7 +479,7 @@ func (bm *BasicModule) registerHooks(hks []*hooks.ModuleHook, logger *log.Logger
 		// TODO: we could make multierr here and return all config errors at once
 		err := moduleHook.InitializeHookConfig()
 		if err != nil {
-			return fmt.Errorf("module hook --config invalid: %w", err)
+			return fmt.Errorf("`%s` module hook `%s` --config invalid: %w", bm.Name, moduleHook.GetName(), err)
 		}
 
 		bm.logger.Debug("module hook config print", slog.String("module_name", bm.Name), slog.String("hook_name", moduleHook.GetName()), slog.Any("config", moduleHook.GetHookConfig().V1))


### PR DESCRIPTION
#### Overview

Adding information about the module and the name of Hook to conclusion error, if it occurs when the hook is registered

#### What this PR does / why we need it

Only adding small information to the output of errors