### PR TITLE
[addon-operator] fix/maintenance mode restart fix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,15 +34,8 @@ jobs:
           go mod download
           echo -n "Go modules unpacked size is: " && du -sh $HOME/go/pkg/mod
 
-      - name: Download prebuilt libjq static libraries
-        run: |
-          curl -sSfL https://github.com/flant/libjq-go/releases/download/jq-b6be13d5-0/libjq-glibc-amd64.tgz | tar zxf -
-
       - name: Build binary
         run: |
-          export CGO_ENABLED=1
-          export CGO_CFLAGS="-I$GITHUB_WORKSPACE/libjq/include"
-          export CGO_LDFLAGS="-L$GITHUB_WORKSPACE/libjq/lib"
           export GOOS=linux
 
           go build ./cmd/addon-operator

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,8 +34,15 @@ jobs:
           go mod download
           echo -n "Go modules unpacked size is: " && du -sh $HOME/go/pkg/mod
 
+      - name: Download prebuilt libjq static libraries
+        run: |
+          curl -sSfL https://github.com/flant/libjq-go/releases/download/jq-b6be13d5-0/libjq-glibc-amd64.tgz | tar zxf -
+
       - name: Build binary
         run: |
+          export CGO_ENABLED=1
+          export CGO_CFLAGS="-I$GITHUB_WORKSPACE/libjq/include"
+          export CGO_LDFLAGS="-L$GITHUB_WORKSPACE/libjq/lib"
           export GOOS=linux
 
           go build ./cmd/addon-operator

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,11 +35,18 @@ jobs:
           go mod download
           echo -n "Go modules unpacked size is: " && du -sh $HOME/go/pkg/mod
 
+      - name: Download prebuilt libjq static libraries
+        run: |
+          curl -sSfL https://github.com/flant/libjq-go/releases/download/jq-b6be13d5-0/libjq-glibc-amd64.tgz | tar zxf -
+
       - name: Run unit tests
         run: |
+          export CGO_ENABLED=1
+          export CGO_CFLAGS="-I$GITHUB_WORKSPACE/libjq/include"
+          export CGO_LDFLAGS="-L$GITHUB_WORKSPACE/libjq/lib"
           export GOOS=linux
 
           go test \
-            --race \
+
             -tags use_libjq \
             ./cmd/... ./pkg/...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,6 +47,6 @@ jobs:
           export GOOS=linux
 
           go test \
-
+            --race \
             -tags use_libjq \
             ./cmd/... ./pkg/...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,6 +47,5 @@ jobs:
           export GOOS=linux
 
           go test \
-            --race \
             -tags use_libjq \
             ./cmd/... ./pkg/...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,17 +35,11 @@ jobs:
           go mod download
           echo -n "Go modules unpacked size is: " && du -sh $HOME/go/pkg/mod
 
-      - name: Download prebuilt libjq static libraries
-        run: |
-          curl -sSfL https://github.com/flant/libjq-go/releases/download/jq-b6be13d5-0/libjq-glibc-amd64.tgz | tar zxf -
-
       - name: Run unit tests
         run: |
-          export CGO_ENABLED=1
-          export CGO_CFLAGS="-I$GITHUB_WORKSPACE/libjq/include"
-          export CGO_LDFLAGS="-L$GITHUB_WORKSPACE/libjq/lib"
           export GOOS=linux
 
           go test \
+            --race \
             -tags use_libjq \
             ./cmd/... ./pkg/...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,5 +41,4 @@ jobs:
 
           go test \
             --race \
-            -tags use_libjq \
             ./cmd/... ./pkg/...

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,13 @@ RUN git clone https://github.com/flant/shell-operator shell-operator-clone && \
     git checkout v1.4.10
 
 RUN shellOpVer=$(go list -m all | grep shell-operator | cut -d' ' -f 2-) \
-    CGO_ENABLED=1 \
-    CGO_CFLAGS="-I/libjq/include" \
-    CGO_LDFLAGS="-L/libjq/lib" \
     GOOS=linux \
     go build -ldflags="-linkmode external -extldflags '-static' -s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$shellOpVer' -X 'github.com/flant/addon-operator/pkg/app.Version=$appVersion'" \
-             -tags use_libjq \
              -o addon-operator \
              ./cmd/addon-operator
 
 # Build helm post-renderer binary (required if helm3 binary is in use)
-RUN CGO_ENABLED=1 \
-    GOOS=linux \
+RUN GOOS=linux \
     go build -o post-renderer ./cmd/post-renderer
 
 # Final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD . /app
 # Clone shell-operator to get frameworks
 RUN git clone https://github.com/flant/shell-operator shell-operator-clone && \
     cd shell-operator-clone && \
-    git checkout v1.4.10
+    git checkout v1.7.2
 
 RUN shellOpVer=$(go list -m all | grep shell-operator | cut -d' ' -f 2-) \
     GOOS=linux \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# Prebuilt libjq.
+FROM --platform=${TARGETPLATFORM:-linux/amd64} flant/jq:b6be13d5-musl as libjq
+
+# Go builder.
+
 FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.23-alpine AS builder
 
 
@@ -9,21 +14,27 @@ ADD go.mod go.sum /app/
 WORKDIR /app
 RUN go mod download
 
+COPY --from=libjq /libjq /libjq
 ADD . /app
 
 # Clone shell-operator to get frameworks
 RUN git clone https://github.com/flant/shell-operator shell-operator-clone && \
     cd shell-operator-clone && \
-    git checkout v1.7.0
+    git checkout v1.4.10
 
 RUN shellOpVer=$(go list -m all | grep shell-operator | cut -d' ' -f 2-) \
+    CGO_ENABLED=1 \
+    CGO_CFLAGS="-I/libjq/include" \
+    CGO_LDFLAGS="-L/libjq/lib" \
     GOOS=linux \
-    go build -ldflags="-s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$shellOpVer' -X 'github.com/flant/addon-operator/pkg/app.Version=$appVersion'" \
+    go build -ldflags="-linkmode external -extldflags '-static' -s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$shellOpVer' -X 'github.com/flant/addon-operator/pkg/app.Version=$appVersion'" \
+             -tags use_libjq \
              -o addon-operator \
              ./cmd/addon-operator
 
 # Build helm post-renderer binary (required if helm3 binary is in use)
-RUN GOOS=linux \
+RUN CGO_ENABLED=1 \
+    GOOS=linux \
     go build -o post-renderer ./cmd/post-renderer
 
 # Final image
@@ -40,6 +51,7 @@ RUN apk --no-cache add ca-certificates bash sed tini && \
     wget https://get.helm.sh/helm-v3.10.3-${helmArch}.tar.gz -O /helm.tgz && \
     tar -z -x -C /bin -f /helm.tgz --strip-components=1 ${helmArch}/helm && \
     rm -f /helm.tgz
+COPY --from=libjq /bin/jq /usr/bin
 COPY --from=builder /app/addon-operator /
 COPY --from=builder /app/post-renderer /
 COPY --from=builder /app/shell-operator-clone/frameworks/shell/ /framework/shell/

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flant/libjq-go v1.6.2 // indirect
+	github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee // indirect
 	github.com/flopp/go-findfont v0.1.0 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flant/libjq-go v1.6.2 // indirect
+	github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee // indirect
 	github.com/flopp/go-findfont v0.1.0 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect
@@ -196,7 +196,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-// Remove 'in body' from errors, fix for Go 1.16 (https://github.com/go-openapi/validate/pull/138).
 // Remove 'in body' from errors, fix for Go 1.16 (https://github.com/go-openapi/validate/pull/138).
 replace github.com/go-openapi/validate => github.com/flant/go-openapi-validate v0.19.12-flant.1
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dominikbraun/graph v0.23.0
 	github.com/ettle/strcase v0.2.0
 	github.com/flant/kube-client v1.3.0
-	github.com/flant/shell-operator v1.7.2-0.20250428153028-deb2e0694527
+	github.com/flant/shell-operator v1.7.2
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-openapi/loads v0.19.5
 	github.com/go-openapi/spec v0.19.8
@@ -78,7 +78,6 @@ require (
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee // indirect
 	github.com/flopp/go-findfont v0.1.0 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect
@@ -112,6 +111,8 @@ require (
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/itchyny/gojq v0.12.17 // indirect
+	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -175,7 +176,7 @@ require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee // indirect
+	github.com/flant/libjq-go v1.6.2 // indirect
 	github.com/flopp/go-findfont v0.1.0 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AW
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.3.0 h1:iVxwpUZO4AhURkq6n44qfzp0Bjs5WatzTtJrfxeRDkE=
 github.com/flant/kube-client v1.3.0/go.mod h1:yaFoNwyomNm0/OLXRxGYvR7or2pfLv9M9qPDSPPwljI=
-github.com/flant/libjq-go v1.6.2 h1:uWEVFKyepRxwA/zH6O8bcb67Kcun+XkioOk4n5TyGQg=
-github.com/flant/libjq-go v1.6.2/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
+github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee h1:evii83J+/6QGNvyf6tjQ/p27DPY9iftxIBb37ALJRTg=
+github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
 github.com/flant/shell-operator v1.7.2-0.20250428153028-deb2e0694527 h1:Tq6W9cpmDCtcOKs9w2l+zb/D582OGIHpRzd1Lb4ody0=
 github.com/flant/shell-operator v1.7.2-0.20250428153028-deb2e0694527/go.mod h1:ohdPK5E/THK4FbHX7nmr6Z4ltHtE8y5z5fkWAf3xQo0=
 github.com/flopp/go-findfont v0.1.0 h1:lPn0BymDUtJo+ZkV01VS3661HL6F4qFlkhcJN55u6mU=

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AW
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.3.0 h1:iVxwpUZO4AhURkq6n44qfzp0Bjs5WatzTtJrfxeRDkE=
 github.com/flant/kube-client v1.3.0/go.mod h1:yaFoNwyomNm0/OLXRxGYvR7or2pfLv9M9qPDSPPwljI=
-github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee h1:evii83J+/6QGNvyf6tjQ/p27DPY9iftxIBb37ALJRTg=
-github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
+github.com/flant/libjq-go v1.6.2 h1:uWEVFKyepRxwA/zH6O8bcb67Kcun+XkioOk4n5TyGQg=
+github.com/flant/libjq-go v1.6.2/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
 github.com/flant/shell-operator v1.7.2-0.20250428153028-deb2e0694527 h1:Tq6W9cpmDCtcOKs9w2l+zb/D582OGIHpRzd1Lb4ody0=
 github.com/flant/shell-operator v1.7.2-0.20250428153028-deb2e0694527/go.mod h1:ohdPK5E/THK4FbHX7nmr6Z4ltHtE8y5z5fkWAf3xQo0=
 github.com/flopp/go-findfont v0.1.0 h1:lPn0BymDUtJo+ZkV01VS3661HL6F4qFlkhcJN55u6mU=

--- a/go.sum
+++ b/go.sum
@@ -144,10 +144,8 @@ github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AW
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.3.0 h1:iVxwpUZO4AhURkq6n44qfzp0Bjs5WatzTtJrfxeRDkE=
 github.com/flant/kube-client v1.3.0/go.mod h1:yaFoNwyomNm0/OLXRxGYvR7or2pfLv9M9qPDSPPwljI=
-github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee h1:evii83J+/6QGNvyf6tjQ/p27DPY9iftxIBb37ALJRTg=
-github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
-github.com/flant/shell-operator v1.7.2-0.20250428153028-deb2e0694527 h1:Tq6W9cpmDCtcOKs9w2l+zb/D582OGIHpRzd1Lb4ody0=
-github.com/flant/shell-operator v1.7.2-0.20250428153028-deb2e0694527/go.mod h1:ohdPK5E/THK4FbHX7nmr6Z4ltHtE8y5z5fkWAf3xQo0=
+github.com/flant/shell-operator v1.7.2 h1:7qyRV7a5yaX0hQt9wTwbxwBv3sdDrP2Fw1KozOvaXV0=
+github.com/flant/shell-operator v1.7.2/go.mod h1:7IDbBSRdoWtKojGnhxnb3JlNF97Q7+mbR0UXhxF5yGg=
 github.com/flopp/go-findfont v0.1.0 h1:lPn0BymDUtJo+ZkV01VS3661HL6F4qFlkhcJN55u6mU=
 github.com/flopp/go-findfont v0.1.0/go.mod h1:wKKxRDjD024Rh7VMwoU90i6ikQRCr+JTHB5n4Ejkqvw=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
@@ -299,8 +297,8 @@ github.com/google/go-containerregistry v0.17.0/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/ZoQgRgVIWFJljSWa/zetS2WTvg=
-github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
+github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
+github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -339,6 +337,10 @@ github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+h
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
+github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
+github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=
+github.com/itchyny/timefmt-go v0.1.6/go.mod h1:RRDZYC5s9ErkjQvTvvU7keJjxUYzIISJGxm9/mAERQg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
@@ -460,9 +462,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo/v2 v2.23.3 h1:edHxnszytJ4lD9D5Jjc4tiDkPBZ3siDeJJkUZJJVkp0=
-github.com/onsi/ginkgo/v2 v2.23.3/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
+github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=
+github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -632,6 +633,8 @@ go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lI
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca h1:VdD38733bfYv5tUZwEIskMM93VanwNIi5bIKnDrJdEY=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
+go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
@@ -718,8 +721,8 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -752,8 +755,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
-golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
-golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
+golang.org/x/tools v0.31.0 h1:0EedkvKDbh+qistFTd0Bcwe/YLh4vHwWEkiI0toFIBU=
+golang.org/x/tools v0.31.0/go.mod h1:naFTU+Cev749tSJRXJlna0T3WxKvb1kWEx15xA4SdmQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/helm/client/client.go
+++ b/pkg/helm/client/client.go
@@ -10,6 +10,7 @@ type HelmClient interface {
 	Render(releaseName string, chart string, valuesPaths []string, setValues []string, namespace string, debug bool) (string, error)
 	GetReleaseValues(releaseName string) (utils.Values, error)
 	GetReleaseChecksum(releaseName string) (string, error)
+	GetReleaseLabels(releaseName, labelName string) (string, error)
 	DeleteRelease(releaseName string) error
 	ListReleasesNames() ([]string, error)
 	IsReleaseExists(releaseName string) (bool, error)

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deckhouse/deckhouse/pkg/log"
+	logContext "github.com/deckhouse/deckhouse/pkg/log/context"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -23,9 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
-
-	"github.com/deckhouse/deckhouse/pkg/log"
-	logContext "github.com/deckhouse/deckhouse/pkg/log/context"
 
 	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/helm/post_renderer"

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -359,6 +359,8 @@ func (h *LibClient) GetReleaseValues(releaseName string) (utils.Values, error) {
 	return gv.Run(releaseName)
 }
 
+var ErrLabelIsNotFound = errors.New("label is not found")
+
 func (h *LibClient) GetReleaseLabels(releaseName, labelName string) (string, error) {
 	gv := action.NewGet(actionConfig)
 	rel, err := gv.Run(releaseName)
@@ -370,7 +372,7 @@ func (h *LibClient) GetReleaseLabels(releaseName, labelName string) (string, err
 		return value, nil
 	}
 
-	return "", nil // TODO: remove NoSuchLabel error
+	return "", ErrLabelIsNotFound
 }
 
 // Deprecated: use GetReleaseLabels instead

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -358,6 +358,20 @@ func (h *LibClient) GetReleaseValues(releaseName string) (utils.Values, error) {
 	return gv.Run(releaseName)
 }
 
+func (h *LibClient) GetReleaseLabels(releaseName, labelName string) (string, error) {
+	gv := action.NewGet(actionConfig)
+	rel, err := gv.Run(releaseName)
+	if err != nil {
+		return "", fmt.Errorf("helm get failed: %s", err)
+	}
+
+	if value, ok := rel.Labels[labelName]; ok {
+		return value, nil
+	}
+
+	return "", nil // TODO: remove NoSuchLabel error
+}
+
 func (h *LibClient) GetReleaseChecksum(releaseName string) (string, error) {
 	gv := action.NewGet(actionConfig)
 	rel, err := gv.Run(releaseName)

--- a/pkg/helm/helm3lib/helm3lib.go
+++ b/pkg/helm/helm3lib/helm3lib.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
-	logContext "github.com/deckhouse/deckhouse/pkg/log/context"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -25,6 +23,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	logContext "github.com/deckhouse/deckhouse/pkg/log/context"
 
 	"github.com/flant/addon-operator/pkg/helm/client"
 	"github.com/flant/addon-operator/pkg/helm/post_renderer"
@@ -372,6 +373,7 @@ func (h *LibClient) GetReleaseLabels(releaseName, labelName string) (string, err
 	return "", nil // TODO: remove NoSuchLabel error
 }
 
+// Deprecated: use GetReleaseLabels instead
 func (h *LibClient) GetReleaseChecksum(releaseName string) (string, error) {
 	gv := action.NewGet(actionConfig)
 	rel, err := gv.Run(releaseName)

--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -14,11 +14,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/gofrs/uuid/v5"
 	"github.com/hashicorp/go-multierror"
 	"github.com/kennygrant/sanitize"
-
-	"github.com/deckhouse/deckhouse/pkg/log"
 
 	"github.com/flant/addon-operator/pkg"
 	"github.com/flant/addon-operator/pkg/app"

--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -14,10 +14,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/gofrs/uuid/v5"
 	"github.com/hashicorp/go-multierror"
 	"github.com/kennygrant/sanitize"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 
 	"github.com/flant/addon-operator/pkg"
 	"github.com/flant/addon-operator/pkg/app"
@@ -191,8 +192,8 @@ func (bm *BasicModule) ResetState() {
 	bm.l.Lock()
 	var maintenanceState MaintenanceState
 
-	if bm.state.maintenanceState == UnmanagedEnforced {
-		maintenanceState = UnmanagedEnabled
+	if bm.state.maintenanceState == Unmanaged {
+		maintenanceState = Unmanaged
 	}
 
 	bm.state = &moduleState{
@@ -550,7 +551,7 @@ func (bm *BasicModule) SetMaintenanceState(state utils.Maintenance) {
 	switch state {
 	case utils.NoResourceReconciliation:
 		if bm.state.maintenanceState == Managed {
-			bm.state.maintenanceState = UnmanagedEnabled
+			bm.state.maintenanceState = Unmanaged
 		}
 	case utils.Managed:
 		if bm.state.maintenanceState != Managed {
@@ -560,10 +561,10 @@ func (bm *BasicModule) SetMaintenanceState(state utils.Maintenance) {
 	bm.l.Unlock()
 }
 
-func (bm *BasicModule) SetUnmanagedEnforced() {
+func (bm *BasicModule) SetUnmanaged() {
 	bm.l.Lock()
-	if bm.state.maintenanceState == UnmanagedEnabled {
-		bm.state.maintenanceState = UnmanagedEnforced
+	if bm.state.maintenanceState == Managed {
+		bm.state.maintenanceState = Unmanaged
 	}
 	bm.l.Unlock()
 }
@@ -1290,10 +1291,8 @@ type MaintenanceState int
 const (
 	// Module runs in a normal mode
 	Managed MaintenanceState = iota
-	// Next helm run will enforce NoResourceReconciliation mode (removes heritage labels and stops resource informer)
-	UnmanagedEnabled
-	// All consequent helm runs are inhibited
-	UnmanagedEnforced
+	// All consequent helm runs are inhibited (heritage labels are removed and resource informer is stopped)
+	Unmanaged = 1
 )
 
 type moduleState struct {

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	LabelMaintenanceNoResourceReconcillation = "maintenance.deckhouse.io/no-resource-reconcillation"
+	LabelMaintenanceNoResourceReconciliation = "maintenance.deckhouse.io/no-resource-reconciliation"
 )
 
 // HelmModule representation of the module, which has Helm Chart and could be installed with the helm lib
@@ -83,7 +83,7 @@ func NewHelmModule(bm *BasicModule, namespace string, tmpDir string, deps *HelmM
 
 	additionalLabels := make(map[string]string)
 	if bm.GetMaintenanceState() != Managed {
-		additionalLabels[LabelMaintenanceNoResourceReconcillation] = ""
+		additionalLabels[LabelMaintenanceNoResourceReconciliation] = ""
 	}
 
 	hm := &HelmModule{
@@ -202,7 +202,7 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 	helmClient := hm.dependencies.HelmClientFactory.NewClient(hm.logger.Named("helm-client"), helmClientOptions...)
 
 	if state == Unmanaged {
-		isUnmanaged, err := helmClient.GetReleaseLabels(helmReleaseName, LabelMaintenanceNoResourceReconcillation)
+		isUnmanaged, err := helmClient.GetReleaseLabels(helmReleaseName, LabelMaintenanceNoResourceReconciliation)
 		if err != nil && !errors.Is(err, helm3lib.ErrLabelIsNotFound) {
 			return fmt.Errorf("get release label failed: %w", err)
 		}
@@ -299,7 +299,7 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 		}
 
 		if state == Unmanaged {
-			releaseLabels[LabelMaintenanceNoResourceReconcillation] = "true"
+			releaseLabels[LabelMaintenanceNoResourceReconciliation] = "true"
 		}
 
 		err = helmClient.UpgradeRelease(

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -168,6 +168,9 @@ func (hm *HelmModule) checkHelmValues() error {
 
 var ErrReleaseIsUnmanaged = errors.New("release is unmanaged")
 
+// RunHelmInstall installs or upgrades a Helm release for the module.
+// The `state` parameter determines the maintenance state of the release:
+// - If `state` is `Unmanaged`, a release label check is triggered, and the Helm upgrade is skipped.
 func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state MaintenanceState) error {
 	metricLabels := map[string]string{
 		"module":                hm.name,

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -18,9 +18,14 @@ import (
 	"github.com/flant/addon-operator/pkg"
 	"github.com/flant/addon-operator/pkg/helm"
 	"github.com/flant/addon-operator/pkg/helm/client"
+	helm3lib "github.com/flant/addon-operator/pkg/helm/helm3lib"
 	"github.com/flant/addon-operator/pkg/utils"
 	"github.com/flant/kube-client/manifest"
 	"github.com/flant/shell-operator/pkg/utils/measure"
+)
+
+const (
+	LabelMaintenanceNoResourceReconcillation = "maintenance.deckhouse.io/no-resource-reconcillation"
 )
 
 // HelmModule representation of the module, which has Helm Chart and could be installed with the helm lib
@@ -78,7 +83,7 @@ func NewHelmModule(bm *BasicModule, namespace string, tmpDir string, deps *HelmM
 
 	additionalLabels := make(map[string]string)
 	if bm.GetMaintenanceState() != Managed {
-		additionalLabels["maintenance.deckhouse.io/no-resource-reconcillation"] = ""
+		additionalLabels[LabelMaintenanceNoResourceReconcillation] = ""
 	}
 
 	hm := &HelmModule{
@@ -161,6 +166,8 @@ func (hm *HelmModule) checkHelmValues() error {
 	return hm.validator.ValidateModuleHelmValues(utils.ModuleNameToValuesKey(hm.name), hm.values)
 }
 
+var ErrReleaseIsUnmanaged = errors.New("release is unmanaged")
+
 func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state MaintenanceState) error {
 	metricLabels := map[string]string{
 		"module":                hm.name,
@@ -195,14 +202,14 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 	helmClient := hm.dependencies.HelmClientFactory.NewClient(hm.logger.Named("helm-client"), helmClientOptions...)
 
 	if state == Unmanaged {
-		// TODO: think about label name
-		isUnmanaged, err := helmClient.GetReleaseLabels(helmReleaseName, "isUnmanaged")
-		if err != nil {
+		isUnmanaged, err := helmClient.GetReleaseLabels(helmReleaseName, LabelMaintenanceNoResourceReconcillation)
+		if err != nil && !errors.Is(err, helm3lib.ErrLabelIsNotFound) {
 			return fmt.Errorf("get release label failed: %w", err)
 		}
 
 		if isUnmanaged == "true" {
 			logEntry.Info("helm release is Unmanaged, skip helm upgrade", slog.String("release", helmReleaseName))
+
 			return nil
 		}
 	}
@@ -217,6 +224,7 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 			pkg.MetricKeyActivation: logLabels[pkg.LogKeyEventType],
 			"operation":             "template",
 		}
+
 		defer measure.Duration(func(d time.Duration) {
 			hm.dependencies.MetricsStorage.HistogramObserve("{PREFIX}helm_operation_seconds", d.Seconds(), metricLabels, nil)
 		})()
@@ -233,15 +241,16 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 	if err != nil {
 		return err
 	}
+
 	checksum := utils.CalculateStringsChecksum(renderedManifests)
 
 	manifests, err := manifest.ListFromYamlDocs(renderedManifests)
 	if err != nil {
 		return err
 	}
+
 	logEntry.Debug("chart has resources", slog.Int("count", len(manifests)))
 
-	// TODO: if Unmanaged, we should always run helm upgrade, skip this check
 	// Skip upgrades if nothing is changed
 	var runUpgradeRelease bool
 	func() {
@@ -267,6 +276,7 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 		if !hm.dependencies.HelmResourceManager.HasMonitor(hm.name) {
 			hm.dependencies.HelmResourceManager.StartMonitor(hm.name, manifests, hm.defaultNamespace, helmClient.LastReleaseStatus)
 		}
+
 		return nil
 	}
 
@@ -279,6 +289,7 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 			pkg.MetricKeyActivation: logLabels[pkg.LogKeyEventType],
 			"operation":             "upgrade",
 		}
+
 		defer measure.Duration(func(d time.Duration) {
 			hm.dependencies.MetricsStorage.HistogramObserve("{PREFIX}helm_operation_seconds", d.Seconds(), metricLabels, nil)
 		})()

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -298,7 +298,8 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 		})()
 
 		releaseLabels := map[string]string{
-			"moduleChecksum": checksum,
+			"moduleChecksum":                         checksum,
+			LabelMaintenanceNoResourceReconciliation: "false",
 		}
 
 		if state == Unmanaged {

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -299,7 +299,7 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 		}
 
 		if state == Unmanaged {
-			releaseLabels["isUnamanged"] = "true"
+			releaseLabels[LabelMaintenanceNoResourceReconcillation] = "true"
 		}
 
 		err = helmClient.UpgradeRelease(

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -210,7 +210,7 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state Maintena
 		if isUnmanaged == "true" {
 			logEntry.Info("helm release is Unmanaged, skip helm upgrade", slog.String("release", helmReleaseName))
 
-			return nil
+			return ErrReleaseIsUnmanaged
 		}
 	}
 

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -11,8 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/hashicorp/go-multierror"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 
 	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm"
@@ -743,6 +744,10 @@ func (mm *ModuleManager) RunModule(moduleName string, logLabels map[string]strin
 
 	if err == nil {
 		moduleMaintenanceState := bm.GetMaintenanceState()
+		err = helmModule.RunHelmInstall(logLabels, moduleMaintenanceState)
+		// TODO: if isUnamanged label is set in this run
+		// run mm.dependencies.HelmResourcesManager.StopMonitor(moduleName)
+
 		if moduleMaintenanceState != modules.UnmanagedEnforced {
 			err = helmModule.RunHelmInstall(logLabels)
 		}

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -743,9 +743,7 @@ func (mm *ModuleManager) RunModule(moduleName string, logLabels map[string]strin
 	}
 
 	if err == nil {
-		moduleMaintenanceState := bm.GetMaintenanceState()
-
-		err = helmModule.RunHelmInstall(logLabels, moduleMaintenanceState)
+		err = helmModule.RunHelmInstall(logLabels, bm.GetMaintenanceState())
 		if err != nil && errors.Is(err, modules.ErrReleaseIsUnmanaged) {
 			bm.SetUnmanaged()
 			mm.dependencies.HelmResourcesManager.StopMonitor(moduleName)

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -11,9 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/helm"

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -744,16 +744,13 @@ func (mm *ModuleManager) RunModule(moduleName string, logLabels map[string]strin
 
 	if err == nil {
 		moduleMaintenanceState := bm.GetMaintenanceState()
+
 		err = helmModule.RunHelmInstall(logLabels, moduleMaintenanceState)
 		if err != nil && errors.Is(err, modules.ErrReleaseIsUnmanaged) {
 			bm.SetUnmanaged()
 			mm.dependencies.HelmResourcesManager.StopMonitor(moduleName)
 
 			err = nil
-		}
-
-		if moduleMaintenanceState != modules.Unmanaged {
-			err = helmModule.RunHelmInstall(logLabels, moduleMaintenanceState)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

When ModuleConfig maintenance mod in NoResourceReconcillation
Set to helm release label `"maintenance.deckhouse.io/no-resource-reconcillation": true` when all resources applied
In next reconcile (for example after restart addon-operator), it looks that release label exists and equals `true`, if it was - stop reconcile helm release.

##### Before
If we delete resource from corresponding Module and restart Addop-Operator
Resource will be recreated

##### After
If we delete resource from corresponding Module and restart Addop-Operator
Resource will not recreated


<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
