### PR TITLE
[addon-operator] 1.6 maintenance mode restart fix 

### DIFF
--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -190,8 +190,8 @@ func (bm *BasicModule) ResetState() {
 	bm.l.Lock()
 	var maintenanceState MaintenanceState
 
-	if bm.state.maintenanceState == UnmanagedEnforced {
-		maintenanceState = UnmanagedEnabled
+	if bm.state.maintenanceState == Unmanaged {
+		maintenanceState = Unmanaged
 	}
 
 	bm.state = &moduleState{
@@ -549,7 +549,7 @@ func (bm *BasicModule) SetMaintenanceState(state utils.Maintenance) {
 	switch state {
 	case utils.NoResourceReconciliation:
 		if bm.state.maintenanceState == Managed {
-			bm.state.maintenanceState = UnmanagedEnabled
+			bm.state.maintenanceState = Unmanaged
 		}
 	case utils.Managed:
 		if bm.state.maintenanceState != Managed {
@@ -559,10 +559,10 @@ func (bm *BasicModule) SetMaintenanceState(state utils.Maintenance) {
 	bm.l.Unlock()
 }
 
-func (bm *BasicModule) SetUnmanagedEnforced() {
+func (bm *BasicModule) SetUnmanaged() {
 	bm.l.Lock()
-	if bm.state.maintenanceState == UnmanagedEnabled {
-		bm.state.maintenanceState = UnmanagedEnforced
+	if bm.state.maintenanceState == Managed {
+		bm.state.maintenanceState = Unmanaged
 	}
 	bm.l.Unlock()
 }
@@ -1290,10 +1290,8 @@ type MaintenanceState int
 const (
 	// Module runs in a normal mode
 	Managed MaintenanceState = iota
-	// Next helm run will enforce NoResourceReconciliation mode (removes heritage labels and stops resource informer)
-	UnmanagedEnabled
-	// All consequent helm runs are inhibited
-	UnmanagedEnforced
+	// All consequent helm runs are inhibited (heritage labels are removed and resource informer is stopped)
+	Unmanaged = 1
 )
 
 type moduleState struct {

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	LabelMaintenanceNoResourceReconciliation = "maintenance.deckhouse.io/no-resource-reconciliation"
+	LabelMaintenanceNoResourceReconciliation = "_maintenance.deckhouse.io/no-resource-reconciliation"
 )
 
 // HelmModule representation of the module, which has Helm Chart and could be installed with the helm lib

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -22,6 +22,10 @@ import (
 	"github.com/flant/shell-operator/pkg/utils/measure"
 )
 
+const (
+	LabelMaintenanceNoResourceReconciliation = "maintenance.deckhouse.io/no-resource-reconciliation"
+)
+
 // HelmModule representation of the module, which has Helm Chart and could be installed with the helm lib
 type HelmModule struct {
 	// Name of the module
@@ -77,7 +81,7 @@ func NewHelmModule(bm *BasicModule, namespace string, tmpDir string, deps *HelmM
 
 	additionalLabels := make(map[string]string)
 	if bm.GetMaintenanceState() != Managed {
-		additionalLabels["maintenance.deckhouse.io/no-resource-reconcillation"] = ""
+		additionalLabels[LabelMaintenanceNoResourceReconciliation] = ""
 	}
 
 	hm := &HelmModule{
@@ -160,7 +164,12 @@ func (hm *HelmModule) checkHelmValues() error {
 	return hm.validator.ValidateModuleHelmValues(utils.ModuleNameToValuesKey(hm.name), hm.values)
 }
 
-func (hm *HelmModule) RunHelmInstall(logLabels map[string]string) error {
+var ErrReleaseIsUnmanaged = errors.New("release is unmanaged")
+
+// RunHelmInstall installs or upgrades a Helm release for the module.
+// The `state` parameter determines the maintenance state of the release:
+// - If `state` is `Unmanaged`, a release label check is triggered, and the Helm upgrade is skipped.
+func (hm *HelmModule) RunHelmInstall(logLabels map[string]string, state MaintenanceState) error {
 	metricLabels := map[string]string{
 		"module":     hm.name,
 		"activation": logLabels["event.type"],
@@ -192,6 +201,21 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string) error {
 	}
 
 	helmClient := hm.dependencies.HelmClientFactory.NewClient(hm.logger.Named("helm-client"), helmClientOptions...)
+
+	if state == Unmanaged {
+		releaseValues, err := helmClient.GetReleaseValues(helmReleaseName)
+		if err != nil {
+			return fmt.Errorf("get release label failed: %w", err)
+		}
+
+		isUnmanaged := releaseValues[LabelMaintenanceNoResourceReconciliation]
+
+		if isUnmanaged == "true" {
+			logEntry.Info("helm release is Unmanaged, skip helm upgrade", slog.String("release", helmReleaseName))
+
+			return ErrReleaseIsUnmanaged
+		}
+	}
 
 	// Render templates to prevent excess helm runs.
 	var renderedManifests string
@@ -268,11 +292,20 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string) error {
 			hm.dependencies.MetricsStorage.HistogramObserve("{PREFIX}helm_operation_seconds", d.Seconds(), metricLabels, nil)
 		})()
 
+		releaseValues := map[string]string{
+			"_addonOperatorModuleChecksum":           checksum,
+			LabelMaintenanceNoResourceReconciliation: "false",
+		}
+
+		if state == Unmanaged {
+			releaseValues[LabelMaintenanceNoResourceReconciliation] = "true"
+		}
+
 		err = helmClient.UpgradeRelease(
 			helmReleaseName,
 			hm.path,
 			[]string{valuesPath},
-			[]string{fmt.Sprintf("_addonOperatorModuleChecksum=%s", checksum)},
+			valuesFromMap(releaseValues),
 			hm.defaultNamespace,
 		)
 	}()
@@ -285,6 +318,14 @@ func (hm *HelmModule) RunHelmInstall(logLabels map[string]string) error {
 	hm.dependencies.HelmResourceManager.StartMonitor(hm.name, manifests, hm.defaultNamespace, helmClient.LastReleaseStatus)
 
 	return nil
+}
+
+func valuesFromMap(input map[string]string) []string {
+	values := make([]string, 0, len(input))
+	for k, v := range input {
+		values = append(values, fmt.Sprintf("%s=%s", k, v))
+	}
+	return values
 }
 
 // If all these conditions aren't met, helm upgrade can be skipped.

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -742,14 +742,12 @@ func (mm *ModuleManager) RunModule(moduleName string, logLabels map[string]strin
 	}
 
 	if err == nil {
-		moduleMaintenanceState := bm.GetMaintenanceState()
-		if moduleMaintenanceState != modules.UnmanagedEnforced {
-			err = helmModule.RunHelmInstall(logLabels)
-		}
-
-		if moduleMaintenanceState == modules.UnmanagedEnabled {
-			bm.SetUnmanagedEnforced()
+		err = helmModule.RunHelmInstall(logLabels, bm.GetMaintenanceState())
+		if err != nil && errors.Is(err, modules.ErrReleaseIsUnmanaged) {
+			bm.SetUnmanaged()
 			mm.dependencies.HelmResourcesManager.StopMonitor(moduleName)
+
+			err = nil
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

When ModuleConfig maintenance mod in NoResourceReconcillation
Set to helm release value `"maintenance.deckhouse.io/no-resource-reconcillation": true` when all resources applied
In next reconcile (for example after restart addon-operator), it looks that release value exists and equals `true`, if it was - stop reconcile helm release.

##### Before
If we delete resource from corresponding Module and restart Addop-Operator
Resource will be recreated

##### After
If we delete resource from corresponding Module and restart Addop-Operator
Resource will not recreated

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
