### PR TITLE
[basic] Remove hooks version

### DIFF
--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -149,6 +149,19 @@ func matchPrefix(path string, crdsFilters string) bool {
 	return false
 }
 
+func convertHookName(modulePath, hookPath string) (string, error) {
+	hooksIdx := strings.Index(hookPath, "/hooks/")
+	if hooksIdx == -1 {
+		relPath, err := filepath.Rel(filepath.Dir(modulePath), hookPath)
+		if err != nil {
+			return "", err
+		}
+		return relPath, nil
+	}
+	relPath := hookPath[hooksIdx+len("/hooks/"):]
+	return filepath.Join("hooks", relPath), nil
+}
+
 // WithDependencies inject module dependencies
 func (bm *BasicModule) WithDependencies(dep *hooks.HookExecutionDependencyContainer) {
 	bm.dc = dep
@@ -324,8 +337,7 @@ func (bm *BasicModule) searchModuleShellHooks() ([]*kind.ShellHook, error) {
 			})
 			options = append(options, kind.WithPythonVenv(discoveredPythonVenvPath))
 		}
-
-		hookName, err := filepath.Rel(filepath.Dir(bm.Path), hookPath)
+		hookName, err := convertHookName(bm.Path, hookPath)
 		if err != nil {
 			return nil, fmt.Errorf("could not get hook name: %w", err)
 		}
@@ -365,7 +377,7 @@ func (bm *BasicModule) searchModuleBatchHooks() ([]*kind.BatchHook, error) {
 	bm.logger.Debug("sorted paths", slog.Any("paths", hooksRelativePaths))
 
 	for _, hookPath := range hooksRelativePaths {
-		hookName, err := filepath.Rel(filepath.Dir(bm.Path), hookPath)
+		hookName, err := convertHookName(bm.Path, hookPath)
 		if err != nil {
 			return nil, fmt.Errorf("could not get hook name: %w", err)
 		}

--- a/pkg/module_manager/models/modules/basic_test.go
+++ b/pkg/module_manager/models/modules/basic_test.go
@@ -3,6 +3,8 @@ package modules
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	sdkutils "github.com/deckhouse/module-sdk/pkg/utils"
@@ -42,6 +44,26 @@ foo:
   xxx: yyy
 `,
 		res.Values.AsString("yaml"))
+}
+
+func getHookName(hookPath string) string {
+	hooksIdx := strings.Index(hookPath, "/hooks/")
+	if hooksIdx == -1 {
+		return filepath.Base(hookPath)
+	}
+	relPath := hookPath[hooksIdx+len("/hooks/"):]
+	return filepath.Join("hooks", relPath)
+}
+func TestHookNameFormat(t *testing.T) {
+	//module := &BasicModule{Path: "/deckhouse/modules/echo"}
+	hookPath := "/deckhouse/modules/echo/v1.2.3/dddd/test.sh"
+	expected := "hooks/test.sh"
+
+	actual := getHookName(hookPath)
+	if actual != expected {
+		t.Errorf("Expected %q, got %q", expected, actual)
+	}
+
 }
 
 func TestIsFileBatchHook(t *testing.T) {

--- a/pkg/module_manager/models/modules/basic_test.go
+++ b/pkg/module_manager/models/modules/basic_test.go
@@ -1,17 +1,25 @@
 package modules
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	"github.com/deckhouse/deckhouse/pkg/log"
 	sdkutils "github.com/deckhouse/module-sdk/pkg/utils"
+	"github.com/flant/shell-operator/pkg/hook/controller"
+	sh_op_types "github.com/flant/shell-operator/pkg/hook/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/flant/addon-operator/pkg/module_manager/models/hooks"
 	"github.com/flant/addon-operator/pkg/utils"
+
+	objectpatch "github.com/flant/shell-operator/pkg/kube/object_patch"
+	metric_storage "github.com/flant/shell-operator/pkg/metric_storage"
 )
 
 func TestHandleModulePatch(t *testing.T) {
@@ -46,24 +54,124 @@ foo:
 		res.Values.AsString("yaml"))
 }
 
-func getHookName(hookPath string) string {
-	hooksIdx := strings.Index(hookPath, "/hooks/")
-	if hooksIdx == -1 {
-		return filepath.Base(hookPath)
-	}
-	relPath := hookPath[hooksIdx+len("/hooks/"):]
-	return filepath.Join("hooks", relPath)
+func TestConvertHookName(t *testing.T) {
+	name, err := convertHookName("/modules/console/v1.35.3", "/modules/console/v1.35.3/hooks/https/copy_cert.py")
+	require.NoError(t, err)
+	require.Equal(t, "hooks/https/copy_cert.py", name)
 }
-func TestHookNameFormat(t *testing.T) {
-	//module := &BasicModule{Path: "/deckhouse/modules/echo"}
-	hookPath := "/deckhouse/modules/echo/v1.2.3/dddd/test.sh"
-	expected := "hooks/test.sh"
 
-	actual := getHookName(hookPath)
-	if actual != expected {
-		t.Errorf("Expected %q, got %q", expected, actual)
+func TestHookNameNormalizedInStorage(t *testing.T) {
+	modulePath := "/tmp/modules/console/v1.2.3"
+	err := os.MkdirAll(filepath.Join(modulePath, "hooks/https"), 0o755)
+	require.NoError(t, err)
+
+	hookPath := filepath.Join(modulePath, "hooks/https/test_hook.py")
+	err = os.WriteFile(hookPath, []byte(`#!/usr/bin/env python3
+import sys
+import yaml
+
+if "--config" in sys.argv:
+    print(yaml.dump({
+        "configVersion": "v1",
+        "onStartup": 10
+    }))
+    sys.exit(0)
+sys.exit(0)
+`), 0o755)
+	require.NoError(t, err)
+
+	defer os.RemoveAll("/tmp/modules")
+
+	valuesStr := `
+foo: 
+  bar: baz
+`
+	value, err := utils.NewValuesFromBytes([]byte(valuesStr))
+	require.NoError(t, err)
+
+	bm, err := NewBasicModule("console", modulePath, 10, value, nil, nil)
+	require.NoError(t, err)
+
+	bm.WithDependencies(&hooks.HookExecutionDependencyContainer{})
+
+	_, err = bm.RegisterHooks(log.NewLogger(log.Options{}))
+	require.NoError(t, err)
+
+	hooks := bm.GetHooks()
+	require.Len(t, hooks, 1)
+	require.Equal(t, "hooks/https/test_hook.py", hooks[0].GetName())
+}
+func TestHookErrorsSummary(t *testing.T) {
+	bm := &BasicModule{
+		Name:  "test",
+		Path:  "/mod/path",
+		state: &moduleState{hookErrors: make(map[string]error)},
+	}
+	bm.SaveHookError("hooks/https/test.py", errors.New("fail"))
+
+	summary := bm.GetHookErrorsSummary()
+	require.Contains(t, summary, "hooks/https/test.py: fail")
+}
+
+type noopConfigManager struct{}
+
+func (*noopConfigManager) SaveConfigValues(string, utils.Values) error { return nil }
+
+type noopValuesGetter struct{}
+
+func (*noopValuesGetter) GetValues(bool) utils.Values       { return utils.Values{} }
+func (*noopValuesGetter) GetConfigValues(bool) utils.Values { return utils.Values{} }
+
+func TestRunHookByNameWorksWithNormalizedName(t *testing.T) {
+	modulePath := "/tmp/modules/console/v1.2.3"
+	hookPath := filepath.Join(modulePath, "hooks/test.sh")
+	require.NoError(t, os.MkdirAll(filepath.Dir(hookPath), 0o755))
+
+	err := os.WriteFile(hookPath, []byte(`#!/bin/sh
+if [ "$1" = "--config" ]; then
+  echo '{"configVersion":"v1","onStartup":10}'
+  exit 0
+fi
+exit 0
+`), 0o755)
+	require.NoError(t, err)
+
+	defer os.RemoveAll("/tmp/modules")
+
+	bm, err := NewBasicModule("example", modulePath, 1, utils.Values{}, nil, nil)
+	require.NoError(t, err)
+
+	logger := log.NewLogger(log.Options{})
+	storage := metric_storage.NewMetricStorage(context.TODO(), "addon_operator_", false, logger)
+
+	bm.WithDependencies(&hooks.HookExecutionDependencyContainer{
+		HookMetricsStorage: storage,
+		MetricStorage:      storage,
+		KubeObjectPatcher:  objectpatch.NewObjectPatcher(nil, logger),
+		KubeConfigManager:  &noopConfigManager{},
+		GlobalValuesGetter: &noopValuesGetter{},
+	})
+	_, err = bm.RegisterHooks(logger)
+	require.NoError(t, err)
+
+	for _, h := range bm.GetHooks() {
+		h.WithHookController(controller.NewHookController())
+	}
+	for _, h := range bm.GetHooks() {
+		t.Logf("Hook: %s", h.GetName())
+		t.Logf("  HookController nil? %v", h.GetHookController() == nil)
 	}
 
+	_, _, err = bm.RunHookByName(context.TODO(), "hooks/test.sh", sh_op_types.OnStartup, nil, map[string]string{})
+	require.NoError(t, err)
+
+	found := false
+	for _, h := range bm.GetHooks() {
+		if h.GetName() == "hooks/test.sh" {
+			found = true
+		}
+	}
+	require.True(t, found, "hook 'hooks/test.sh' should be registered")
 }
 
 func TestIsFileBatchHook(t *testing.T) {


### PR DESCRIPTION
#### Overview

This PR fixes the incorrect formatting of `hookName` used in `hooksState` and related logging logic. Previously, the hook path included the module version (e.g., `v1.2.3/hooks/...`), which was incorrect and inconsistent. Now, the hook path is normalized to always start with `hooks/...`.

#### What this PR does / why we need it

- Normalizes `hookName` to remove any versioned module path prefix.
- Ensures all hook references (in `hooksState`, logging, error summary, and RunHookByName) use consistent `hooks/...` format.
- Prevents misleading hook paths like `v1.2.3/hooks/...` from being displayed in status and logs.
- Adds a dedicated unit test to verify that modules located at paths like `/tmp/modules/console/v1.2.3` still register hooks as `hooks/...`, and that `RunHookByName("hooks/xyz")` executes properly.

This improves developer experience, correctness of state reporting, and avoids confusion caused by path inconsistencies.

#### Special notes for your reviewer

- Please pay attention to the normalization logic added via `convertHookName()`.
- Test verifies that a hook placed inside a versioned module path is still registered and executable under a normalized name.