### PR TITLE
[addon-operator] Add verbosity to unmarshal error

### DIFF
--- a/pkg/module_manager/go_hook/filter_result.go
+++ b/pkg/module_manager/go_hook/filter_result.go
@@ -22,7 +22,7 @@ type Wrapped struct {
 
 var (
 	ErrEmptyWrapped             = errors.New("empty filter result")
-	ErrUnmarshalToTypesNotMatch = errors.New("unmarshal error: input and output types not match")
+	ErrUnmarshalToTypesNotMatch = errors.New("input and output types not match")
 )
 
 func (f *Wrapped) UnmarshalTo(v any) error {
@@ -44,7 +44,8 @@ func (f *Wrapped) UnmarshalTo(v any) error {
 	}
 
 	if rw.Type() != rv.Type() {
-		return ErrUnmarshalToTypesNotMatch
+		return fmt.Errorf("input type: %s, wrapped type: %s: %w",
+			rv.Type(), rw.Type(), ErrUnmarshalToTypesNotMatch)
 	}
 
 	rv.Elem().Set(rw.Elem())

--- a/pkg/module_manager/go_hook/filter_result_test.go
+++ b/pkg/module_manager/go_hook/filter_result_test.go
@@ -89,6 +89,7 @@ func Test_FilterResult(t *testing.T) {
 
 		err := w.UnmarshalTo(os)
 		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "input type: *go_hook_test.OtherStruct, wrapped type: *go_hook_test.SomeStruct: input and output types not match")
 	})
 
 	t.Run("UnmarshalTo_CustomStructWithMap", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Now we return more verbose error when types does not match

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
