### PR TITLE
fix: clear readiness hooks flag after ModuleDelete

### DIFF
--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -21,6 +21,13 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 
+	shapp "github.com/flant/shell-operator/pkg/app"
+	"github.com/flant/shell-operator/pkg/executor"
+	bindingcontext "github.com/flant/shell-operator/pkg/hook/binding_context"
+	sh_op_types "github.com/flant/shell-operator/pkg/hook/types"
+	utils_file "github.com/flant/shell-operator/pkg/utils/file"
+	"github.com/flant/shell-operator/pkg/utils/measure"
+
 	"github.com/flant/addon-operator/pkg"
 	"github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/hook/types"
@@ -30,12 +37,6 @@ import (
 	"github.com/flant/addon-operator/pkg/utils"
 	"github.com/flant/addon-operator/pkg/values/validation"
 	"github.com/flant/addon-operator/sdk"
-	shapp "github.com/flant/shell-operator/pkg/app"
-	"github.com/flant/shell-operator/pkg/executor"
-	bindingcontext "github.com/flant/shell-operator/pkg/hook/binding_context"
-	sh_op_types "github.com/flant/shell-operator/pkg/hook/types"
-	utils_file "github.com/flant/shell-operator/pkg/utils/file"
-	"github.com/flant/shell-operator/pkg/utils/measure"
 )
 
 // BasicModule is a basic representation of the Module, which addon-operator works with
@@ -201,6 +202,7 @@ func (bm *BasicModule) HasReadiness() bool {
 // DeregisterHooks clean up all module hooks
 func (bm *BasicModule) DeregisterHooks() {
 	bm.hooks.clean()
+	bm.hasReadiness = false
 }
 
 // HooksControllersReady returns controllersReady status of the hook storage


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Clear readiness hooks flag after ModuleDelete


#### What this PR does / why we need it

ModuleDelete and ModuleRun during lifecycle leads to an error:

```
 1. ModuleRun:parallel_queue_8:<MODULE_NAME>:doStartup:ReloadAllModules:failures 121:
register hooks search module hooks failed: search module batch hooks:
multiple readiness hooks found in <HOOK_FILE_PATH>
```

#### Special notes for your reviewer
