### PR TITLE
[fix] inject module registry to values

### DIFF
--- a/pkg/module_manager/models/modules/values_storage.go
+++ b/pkg/module_manager/models/modules/values_storage.go
@@ -186,7 +186,7 @@ func (vs *ValuesStorage) InjectRegistryValue(registry *Registry) {
 
 	vs.schemaStorage.InjectRegistrySpec()
 
-	vs.resultValues["registry"] = registry
+	vs.staticValues["registry"] = registry
 }
 
 // GetConfigValues returns only user defined values

--- a/pkg/module_manager/models/modules/values_storage.go
+++ b/pkg/module_manager/models/modules/values_storage.go
@@ -186,6 +186,10 @@ func (vs *ValuesStorage) InjectRegistryValue(registry *Registry) {
 
 	vs.schemaStorage.InjectRegistrySpec()
 
+	if vs.staticValues == nil {
+		vs.staticValues = utils.Values{}
+	}
+
 	vs.staticValues["registry"] = registry
 }
 

--- a/pkg/module_manager/models/modules/values_storage.go
+++ b/pkg/module_manager/models/modules/values_storage.go
@@ -44,6 +44,7 @@ type ValuesStorage struct {
 	// result of the merging all input values
 	resultValues utils.Values
 }
+
 type Registry struct {
 	Base      string `json:"base" yaml:"base"`
 	DockerCfg string `json:"dockercfg" yaml:"dockercfg"`

--- a/pkg/module_manager/models/modules/values_storage.go
+++ b/pkg/module_manager/models/modules/values_storage.go
@@ -184,7 +184,10 @@ func (vs *ValuesStorage) InjectRegistryValue(registry *Registry) {
 	vs.lock.Lock()
 	defer vs.lock.Unlock()
 
-	vs.schemaStorage.InjectRegistrySpec()
+	// inject spec to values schema
+	vs.schemaStorage.InjectRegistrySpec(validation.ValuesSchema)
+	// inject spec to helm schema
+	vs.schemaStorage.InjectRegistrySpec(validation.HelmValuesSchema)
 
 	if vs.staticValues == nil {
 		vs.staticValues = utils.Values{}

--- a/pkg/module_manager/models/modules/values_storage.go
+++ b/pkg/module_manager/models/modules/values_storage.go
@@ -194,6 +194,8 @@ func (vs *ValuesStorage) InjectRegistryValue(registry *Registry) {
 	}
 
 	vs.staticValues["registry"] = registry
+
+	_ = vs.calculateResultValues()
 }
 
 // GetConfigValues returns only user defined values

--- a/pkg/values/validation/schemas.go
+++ b/pkg/values/validation/schemas.go
@@ -163,8 +163,12 @@ func validateObject(dataObj interface{}, s *spec.Schema, rootName string) error 
 // InjectRegistrySpec mutates the module schema to add a strict-typed "registry" field
 func (st *SchemaStorage) InjectRegistrySpec() {
 	scheme := st.Schemas[ValuesSchema]
-	if scheme == nil || len(scheme.Properties) == 0 {
+	if scheme == nil {
 		return
+	}
+
+	if len(scheme.Properties) == 0 {
+		scheme.Properties = make(map[string]spec.Schema)
 	}
 
 	scheme.Properties["registry"] = spec.Schema{

--- a/pkg/values/validation/schemas.go
+++ b/pkg/values/validation/schemas.go
@@ -161,8 +161,8 @@ func validateObject(dataObj interface{}, s *spec.Schema, rootName string) error 
 }
 
 // InjectRegistrySpec mutates the module schema to add a strict-typed "registry" field
-func (st *SchemaStorage) InjectRegistrySpec() {
-	scheme := st.Schemas[ValuesSchema]
+func (st *SchemaStorage) InjectRegistrySpec(schemaType SchemaType) {
+	scheme := st.Schemas[schemaType]
 	if scheme == nil {
 		return
 	}


### PR DESCRIPTION
#### Overview

Modules(like pod-reloader) may [have no properties](https://github.com/deckhouse/pod-reloader/blob/main/openapi/values.yaml) in values.yaml, we skipped such modules and it causes validation problem.

The problem was not revealed before because it happens only if you delete a module(remove old injection on fs)

```
 1. ModuleRun:parallel_queue_1:pod-reloader:doStartup:OperatorStartup:failures 19:run helm install: check helm values: 1 error occurred:
	* podReloader.registry is a forbidden property
```

And result values are override after recalculation, so use static values

#### What this PR does / why we need it
Fixes the registry injection 

