### PR TITLE
[chore][helm] dont create chart file for helm module

### DIFF
--- a/pkg/helm/client/client.go
+++ b/pkg/helm/client/client.go
@@ -1,13 +1,15 @@
 package client
 
 import (
+	"helm.sh/helm/v3/pkg/chart"
+
 	"github.com/flant/addon-operator/pkg/utils"
 )
 
 type HelmClient interface {
 	LastReleaseStatus(releaseName string) (string, string, error)
-	UpgradeRelease(releaseName string, chart string, valuesPaths []string, setValues []string, releaseLabels map[string]string, namespace string) error
-	Render(releaseName string, chart string, valuesPaths []string, setValues []string, releaseLabels map[string]string, namespace string, debug bool) (string, error)
+	UpgradeRelease(releaseName string, chart *chart.Chart, valuesPaths []string, setValues []string, releaseLabels map[string]string, namespace string) error
+	Render(releaseName string, chart *chart.Chart, valuesPaths []string, setValues []string, releaseLabels map[string]string, namespace string, debug bool) (string, error)
 	GetReleaseValues(releaseName string) (utils.Values, error)
 	GetReleaseChecksum(releaseName string) (string, error)
 	GetReleaseLabels(releaseName, labelName string) (string, error)

--- a/pkg/helm/helm3lib/helm3lib_test.go
+++ b/pkg/helm/helm3lib/helm3lib_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 	. "github.com/onsi/gomega"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
@@ -47,7 +48,10 @@ func TestHelm3LibUpgradeDelete(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(releases).To(BeEmpty(), "should get empty list of releases")
 
-	err = cl.UpgradeRelease("test-release", "testdata/chart", nil, nil, map[string]string{"key": "value"}, cl.Namespace)
+	chart, err := loader.Load("testdata/chart")
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cl.UpgradeRelease("test-release", chart, nil, nil, map[string]string{"key": "value"}, cl.Namespace)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	releasesNames, err := cl.ListReleasesNames()
@@ -91,7 +95,10 @@ func TestReleaseExistsReturnsTrueForExistingRelease(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(releases).To(BeEmpty(), "should get empty list of releases")
 
-	err = cl.UpgradeRelease("existing-release", "testdata/chart", nil, nil, nil, cl.Namespace)
+	chart, err := loader.Load("testdata/chart")
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cl.UpgradeRelease("existing-release", chart, nil, nil, nil, cl.Namespace)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	releases, err = cl.ListReleases()
@@ -129,7 +136,10 @@ func TestDeleteReleaseRemovesExistingRelease(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(releases).To(BeEmpty(), "should get empty list of releases")
 
-	err = cl.UpgradeRelease("release-to-delete", "testdata/chart", nil, nil, nil, cl.Namespace)
+	chart, err := loader.Load("testdata/chart")
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cl.UpgradeRelease("release-to-delete", chart, nil, nil, nil, cl.Namespace)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	releases, err = cl.ListReleases()
@@ -157,7 +167,10 @@ func TestLastReleaseStatusReturnsCorrectStatusForExistingRelease(t *testing.T) {
 	g := NewWithT(t)
 	cl := initHelmClient(t)
 
-	err := cl.UpgradeRelease("status-release", "testdata/chart", nil, nil, nil, cl.Namespace)
+	chart, err := loader.Load("testdata/chart")
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cl.UpgradeRelease("status-release", chart, nil, nil, nil, cl.Namespace)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	revision, status, err := cl.LastReleaseStatus("status-release")

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	. "github.com/onsi/gomega"
+	"helm.sh/helm/v3/pkg/chart/loader"
 
 	"github.com/flant/addon-operator/pkg/helm/helm3lib"
 	"github.com/flant/addon-operator/pkg/helm/nelm"
@@ -51,7 +52,10 @@ func TestHelmFactory(t *testing.T) {
 		g.Expect(err).ShouldNot(HaveOccurred())
 		g.Expect(isExists).Should(BeFalse(), "should not found release in the empty cluster")
 
-		err = helmCl.UpgradeRelease("test-release", "helm3lib/testdata/chart", nil, nil, nil, namespace)
+		chart, err := loader.Load("helm3lib/testdata/chart")
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		err = helmCl.UpgradeRelease("test-release", chart, nil, nil, nil, namespace)
 		g.Expect(err).ShouldNot(HaveOccurred())
 
 		releasesAfterUpgrade, err := helmCl.ListReleasesNames()

--- a/pkg/helm/test/mock/mock.go
+++ b/pkg/helm/test/mock/mock.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"github.com/deckhouse/deckhouse/pkg/log"
+	"helm.sh/helm/v3/pkg/chart"
 
 	"github.com/flant/addon-operator/pkg/helm"
 	"github.com/flant/addon-operator/pkg/helm/client"
@@ -48,7 +49,7 @@ func (c *Client) GetReleaseChecksum(_ string) (string, error) {
 	return "23857cb313d15f43960f4daa7013804e", nil
 }
 
-func (c *Client) UpgradeRelease(_, _ string, _ []string, _ []string, _ map[string]string, _ string) error {
+func (c *Client) UpgradeRelease(_ string, _ *chart.Chart, _ []string, _ []string, _ map[string]string, _ string) error {
 	c.UpgradeReleaseExecuted = true
 	return nil
 }
@@ -58,7 +59,7 @@ func (c *Client) DeleteRelease(_ string) error {
 	return nil
 }
 
-func (c *Client) Render(_ string, _ string, _ []string, _ []string, _ map[string]string, _ string, _ bool) (string, error) {
+func (c *Client) Render(_ string, _ *chart.Chart, _ []string, _ []string, _ map[string]string, _ string, _ bool) (string, error) {
 	return "", nil
 }
 

--- a/pkg/module_manager/models/modules/helm.go
+++ b/pkg/module_manager/models/modules/helm.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -16,12 +17,14 @@ import (
 	"github.com/kennygrant/sanitize"
 	"github.com/werf/nelm/pkg/action"
 	"go.opentelemetry.io/otel"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/storage/driver"
 
 	"github.com/flant/addon-operator/pkg"
 	"github.com/flant/addon-operator/pkg/helm"
 	"github.com/flant/addon-operator/pkg/helm/client"
-	helm3lib "github.com/flant/addon-operator/pkg/helm/helm3lib"
+	"github.com/flant/addon-operator/pkg/helm/helm3lib"
 	"github.com/flant/addon-operator/pkg/utils"
 	"github.com/flant/kube-client/manifest"
 	"github.com/flant/shell-operator/pkg/utils/measure"
@@ -51,6 +54,9 @@ type HelmModule struct {
 	logger *log.Logger
 
 	additionalLabels map[string]string
+
+	// hasChartFile if the module has Chart.yaml
+	hasChartFile bool
 }
 
 type HelmValuesValidator interface {
@@ -135,6 +141,7 @@ func (hm *HelmModule) isHelmChart() (bool, error) {
 	_, err := os.Stat(chartPath)
 	if err == nil {
 		// Chart.yaml exists, consider this module as helm chart
+		hm.hasChartFile = true
 		return true, nil
 	}
 
@@ -143,7 +150,7 @@ func (hm *HelmModule) isHelmChart() (bool, error) {
 		// check that templates/ dir exists
 		_, err = os.Stat(filepath.Join(hm.path, "templates"))
 		if err == nil {
-			return true, hm.createChartYaml(chartPath)
+			return true, nil
 		}
 		if os.IsNotExist(err) {
 			// if templates not exists - it's not a helm module
@@ -154,14 +161,73 @@ func (hm *HelmModule) isHelmChart() (bool, error) {
 	return false, err
 }
 
-func (hm *HelmModule) createChartYaml(chartPath string) error {
-	// we already have versions like 0.1.0 or 0.1.1
-	// to keep helm updatable, we have to increment this version
-	// new minor version of addon-operator seems reasonable to increase minor version of a helm chart
-	data := fmt.Sprintf(`name: %s
-version: 0.2.0`, hm.name)
+// loadChart either loads Chart.yaml from os or makes it virtual
+func (hm *HelmModule) loadChart() (*chart.Chart, error) {
+	// if Chart.yaml exists, load chart from os
+	if hm.hasChartFile {
+		return loader.Load(hm.path)
+	}
 
-	return os.WriteFile(chartPath, []byte(data), 0o644)
+	var files []*loader.BufferedFile
+
+	chartYaml := fmt.Sprintf(`
+name: %s
+version: 0.2.0
+apiVersion: v2`, hm.name)
+
+	files = append(files, &loader.BufferedFile{
+		Name: "Chart.yaml",
+		Data: []byte(chartYaml),
+	})
+
+	ignored := []string{
+		"crds",
+		"docs",
+		"hooks",
+		"images",
+		"lib",
+	}
+
+	err := filepath.Walk(hm.path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			if slices.Contains(ignored, info.Name()) {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		relPath, err := filepath.Rel(hm.path, path)
+		if err != nil {
+			return err
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		files = append(files, &loader.BufferedFile{
+			Name: relPath,
+			Data: data,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read module files: %w", err)
+	}
+
+	loaded, err := loader.LoadFiles(files)
+	if err != nil {
+		return nil, fmt.Errorf("load chart from files: %w", err)
+	}
+
+	return loaded, nil
 }
 
 // checkHelmValues returns error if there is a wrong patch or values are not satisfied
@@ -233,6 +299,11 @@ func (hm *HelmModule) RunHelmInstall(ctx context.Context, logLabels map[string]s
 
 	span.AddEvent("ModuleRun-HelmPhase-helm-render")
 
+	moduleChart, err := hm.loadChart()
+	if err != nil {
+		return fmt.Errorf("load module chart: %w", err)
+	}
+
 	// Prepare release labels
 	releaseLabels := map[string]string{
 		LabelMaintenanceNoResourceReconciliation: "false",
@@ -257,7 +328,7 @@ func (hm *HelmModule) RunHelmInstall(ctx context.Context, logLabels map[string]s
 
 		renderedManifests, err = helmClient.Render(
 			helmReleaseName,
-			hm.path,
+			moduleChart,
 			[]string{valuesPath},
 			[]string{},
 			releaseLabels,
@@ -324,7 +395,7 @@ func (hm *HelmModule) RunHelmInstall(ctx context.Context, logLabels map[string]s
 
 		err = helmClient.UpgradeRelease(
 			helmReleaseName,
-			hm.path,
+			moduleChart,
 			[]string{valuesPath},
 			[]string{},
 			releaseLabels,
@@ -446,5 +517,11 @@ func (hm *HelmModule) Render(namespace string, debug bool, state MaintenanceStat
 		LabelMaintenanceNoResourceReconciliation: strconv.FormatBool(state == Unmanaged),
 	}
 
-	return hm.dependencies.HelmClientFactory.NewClient(hm.logger.Named("helm-client"), helmClientOptions...).Render(hm.name, hm.path, []string{valuesPath}, nil, releaseLabels, namespace, debug)
+	moduleChart, err := hm.loadChart()
+	if err != nil {
+		return "", fmt.Errorf("load module chart: %v", err)
+	}
+
+	return hm.dependencies.HelmClientFactory.NewClient(hm.logger.Named("helm-client"), helmClientOptions...).
+		Render(hm.name, moduleChart, []string{valuesPath}, nil, releaseLabels, namespace, debug)
 }


### PR DESCRIPTION
#### Overview

Addon tries to create a Chart.yaml for a helm module, but it will fail on read only fs. 
This PR fixes it for helm client.

#### What this PR does / why we need it

If a module does not have Chart.yaml, we make it 'virtual' and call helm loading again. 

WARNING:
IT IS NOT THE BEST SOLUTION, BUT IT SEEMS ENOUGH FOR NOW

WARNING:
NELM DOES NOT SUPPORT IT
