### PR TITLE
Don't disable monitors before after delete hook run

### DIFF
--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -652,8 +652,8 @@ func (mm *ModuleManager) DeleteModule(ctx context.Context, moduleName string, lo
 
 	ml := mm.GetModule(moduleName)
 
-	// Stop kubernetes informers and remove scheduled functions
-	mm.DisableModuleHooks(moduleName)
+	// Note: keep kubernetes monitors alive until afterDeleteHelm runs,
+	// so hooks can access snapshots. We'll disable hooks after running them.
 
 	// DELETE
 	{
@@ -710,6 +710,9 @@ func (mm *ModuleManager) DeleteModule(ctx context.Context, moduleName string, lo
 		if err != nil {
 			return fmt.Errorf("run hooks by bindng: %w", err)
 		}
+
+		// Now it is safe to stop kubernetes informers and remove scheduled functions
+		mm.DisableModuleHooks(moduleName)
 
 		// Cleanup state.
 		ml.ResetState()

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -894,6 +894,18 @@ func (mm *ModuleManager) EnableModuleScheduleBindings(moduleName string) {
 	}
 }
 
+// DisableModuleScheduleBindings disables schedule bindings of the module's hooks
+func (mm *ModuleManager) DisableModuleScheduleBindings(moduleName string) {
+	ml := mm.GetModule(moduleName)
+	if !ml.HooksControllersReady() {
+		return
+	}
+	schHooks := ml.GetHooks(Schedule)
+	for _, mh := range schHooks {
+		mh.GetHookController().DisableScheduleBindings()
+	}
+}
+
 // DisableModuleHooks disables monitors/bindings of the module's hooks
 // It's advisable to use this method only if next step is to completely disable the module (as a short-term commitment).
 // Otherwise, as hooks are rather stateless, their confiuration may get overwritten, resulting in unexpected consequences.

--- a/pkg/task/tasks/converge-modules/task.go
+++ b/pkg/task/tasks/converge-modules/task.go
@@ -147,7 +147,8 @@ func (s *Task) Handle(ctx context.Context) queue.TaskResult {
 			// TODO disable hooks before was done in DiscoverModulesStateRefresh. Should we stick to this solution or disable events later during the handling each ModuleDelete task?
 			// Disable events for disabled modules.
 			for _, moduleName := range state.ModulesToDisable {
-				s.moduleManager.DisableModuleHooks(moduleName)
+				s.moduleManager.DisableModuleScheduleBindings(moduleName)
+				// s.moduleManager.DisableModuleHooks(moduleName)
 				// op.DrainModuleQueues(moduleName)
 			}
 			// Set ModulesToEnable list to properly run onStartup hooks for first converge.


### PR DESCRIPTION
#### Overview
Defer stopping Kubernetes monitors for modules scheduled to be disabled. In converge phase, only disable schedule bindings; keep Kubernetes watchers alive until `afterDeleteHelm` runs during `DeleteModule`. Full hook disabling still happens right after `afterDeleteHelm`.

#### What this PR does / why we need it
- Previously, converge disabled all module hooks (including Kubernetes monitors) immediately for modules in `ModulesToDisable`. As a side effect, `afterDeleteHelm` hooks received empty snapshots because monitors were already stopped.
- This PR:
  - Changes converge to disable only schedule bindings for modules to disable.
  - Leaves Kubernetes monitors running so `DeleteModule` can execute `afterDeleteHelm` with populated snapshots.
  - Keeps the existing cleanup: `DisableModuleHooks` is still invoked in `DeleteModule` right after `afterDeleteHelm`, stopping both schedules and monitors.

Why needed:
- Restores documented behavior that `afterDeleteHelm` hooks receive snapshots of their Kubernetes bindings.
- Unblocks reliable cleanup logic (e.g., deleting CRs/secrets) during module disable.
- Minimizes event noise by keeping schedules off while preventing data loss for snapshots.
