### PR TITLE
[addon-operator] remove search hooks log duplicates

### DIFF
--- a/pkg/module_manager/models/modules/global.go
+++ b/pkg/module_manager/models/modules/global.go
@@ -640,7 +640,7 @@ func (gm *GlobalModule) searchGlobalBatchHooks(hooksDir string) ([]*kind.BatchHo
 		count = strconv.Itoa(len(hks))
 	}
 
-	gm.logger.Info("Found global shell hooks in dir",
+	gm.logger.Info("Found global batch hooks in dir",
 		slog.String("count", count),
 		slog.String("dir", hooksDir))
 


### PR DESCRIPTION
#### Overview

Fixed duplicate log messages during addon-operator startup caused by incorrect logging message in searchGlobalBatchHooks function.

#### What this PR does / why we need it

This PR fixes a logging issue in pkg/module_manager/models/modules/global.go where the searchGlobalBatchHooks function was incorrectly logging "Found global shell hooks in dir" instead of "Found global batch hooks in dir".
