### PR TITLE
[fix] Fix missing startup hooks

### DIFF
--- a/pkg/task/tasks/converge-modules/task.go
+++ b/pkg/task/tasks/converge-modules/task.go
@@ -16,6 +16,7 @@ import (
 	hookTypes "github.com/flant/addon-operator/pkg/hook/types"
 	"github.com/flant/addon-operator/pkg/metrics"
 	"github.com/flant/addon-operator/pkg/module_manager"
+	modulesModel "github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules/events"
 	"github.com/flant/addon-operator/pkg/task"
 	"github.com/flant/addon-operator/pkg/task/functional"
@@ -422,6 +423,10 @@ func (s *Task) CreateConvergeModulesTasks(state *module_manager.ModulesState, lo
 							}).WithQueuedAt(queuedAt))
 					}
 					doModuleStartup = true
+				} else if m := s.moduleManager.GetModule(moduleName); m != nil && m.GetPhase() == modulesModel.Startup {
+					// Module stayed enabled but its previous ModuleRun was interrupted
+					// before onStartup hooks completed. Re-run startup.
+					doModuleStartup = true
 				}
 				parallelRunMetadata.SetModuleMetadata(moduleName, task.ParallelRunModuleMetadata{
 					DoModuleStartup: doModuleStartup,
@@ -461,6 +466,10 @@ func (s *Task) CreateConvergeModulesTasks(state *module_manager.ModulesState, lo
 							IsReloadAll:      true,
 						}).WithQueuedAt(queuedAt))
 				}
+				doModuleStartup = true
+			} else if m := s.moduleManager.GetModule(modules[0]); m != nil && m.GetPhase() == modulesModel.Startup {
+				// Module stayed enabled but its previous ModuleRun was interrupted
+				// before onStartup hooks completed. Re-run startup.
 				doModuleStartup = true
 			}
 			newTask := sh_task.NewTask(task.ModuleRun).
@@ -510,6 +519,10 @@ func (s *Task) CreateConvergeModulesTasks(state *module_manager.ModulesState, lo
 						IsReloadAll:      true,
 					}).WithQueuedAt(queuedAt))
 			}
+			doModuleStartup = true
+		} else if m := s.moduleManager.GetModule(module); m != nil && m.GetPhase() == modulesModel.Startup {
+			// Module stayed enabled but its previous ModuleRun was interrupted
+			// before onStartup hooks completed. Re-run startup.
 			doModuleStartup = true
 		}
 


### PR DESCRIPTION
#### Overview

Fix module startup hooks being skipped when a global reconvergence (e.g., triggered by a config change) interrupts a module that is still in its Startup phase.

#### What this PR does / why we need it

When a config change triggers global reconvergence after the first converge has completed, existing ModuleRun tasks are drained from the queue by RemoveCurrentConvergeTasks. The new ConvergeModules task then rebuilds ModuleRun tasks for all enabled modules. However, it only sets DoModuleStartup: true for modules in the newlyEnabled set - modules that transitioned from disabled to enabled in the scheduler diff.

A module that was already enabled and stays enabled does not appear in the diff, even if its onStartup hooks never completed (its phase is still Startup). The replacement ModuleRun task gets DoModuleStartup: false, causing it to skip onStartup hook execution entirely.

This fix adds a fallback check: if the module is not in newlyEnabled but its phase is still Startup, set DoModuleStartup: true so that onStartup hooks are properly re-run.