### PR TITLE
[feature] export module versions to DOP via mm_module_enabled metric

### DIFF
--- a/pkg/labels.go
+++ b/pkg/labels.go
@@ -125,4 +125,5 @@ const (
 	MetricKeyOperation  = "operation"
 	MetricKeyQueue      = "queue"
 	MetricKeyResource   = "resource"
+	MetricKeyVersion    = "version"
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -45,6 +45,12 @@ var (
 	ModulesAbsentResourcesTotal = "{PREFIX}modules_absent_resources_total"
 	// ModuleInfoMetricName tracks module information
 	ModuleInfoMetricName = "{PREFIX}mm_module_info"
+	// ModuleEnabledMetricName tracks enabled modules with their deployed version
+	ModuleEnabledMetricName = "{PREFIX}mm_module_enabled"
+	// ModuleEnabledTelemetryMetricName mirrors ModuleEnabledMetricName under the
+	// d8_telemetry_ prefix so flant-integration ships the metric to DOP.
+	// The prefix is literal here (no {PREFIX} placeholder) and must stay that way.
+	ModuleEnabledTelemetryMetricName = "d8_telemetry_module_enabled"
 	// ModuleMaintenanceMetricName tracks module maintenance state
 	ModuleMaintenanceMetricName = "{PREFIX}mm_module_maintenance"
 
@@ -152,6 +158,7 @@ func InitMetrics(prefix string) {
 	ModulesHelmReleaseRedeployedTotal = ReplacePrefix(ModulesHelmReleaseRedeployedTotal, prefix)
 	ModulesAbsentResourcesTotal = ReplacePrefix(ModulesAbsentResourcesTotal, prefix)
 	ModuleInfoMetricName = ReplacePrefix(ModuleInfoMetricName, prefix)
+	ModuleEnabledMetricName = ReplacePrefix(ModuleEnabledMetricName, prefix)
 	ModuleMaintenanceMetricName = ReplacePrefix(ModuleMaintenanceMetricName, prefix)
 
 	// ============================================================================

--- a/pkg/module_manager/models/modules/basic.go
+++ b/pkg/module_manager/models/modules/basic.go
@@ -54,6 +54,8 @@ type BasicModule struct {
 	// required
 	Path string
 
+	version string
+
 	critical bool
 
 	crdsExist     bool
@@ -118,6 +120,14 @@ func (bm *BasicModule) WithLogger(logger *log.Logger) {
 
 func (bm *BasicModule) SetCritical(value bool) {
 	bm.critical = value
+}
+
+func (bm *BasicModule) SetVersion(v string) {
+	bm.version = v
+}
+
+func (bm *BasicModule) GetVersion() string {
+	return bm.version
 }
 
 // getCRDsFromPath scan path/crds directory and store yaml file in slice

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -52,6 +52,7 @@ import (
 
 var (
 	moduleInfoMetricGroup        = "mm_module_info"
+	moduleEnabledMetricGroup     = "mm_module_enabled"
 	moduleMaintenanceMetricGroup = "mm_module_maintenance"
 	moduleManagerServiceName     = "module-manager"
 )
@@ -512,6 +513,38 @@ func (mm *ModuleManager) UpdateModulesMetrics() {
 		}
 
 		mm.dependencies.MetricStorage.Grouped().GaugeSet(moduleInfoMetricGroup, metrics.ModuleInfoMetricName, 1, map[string]string{pkg.MetricKeyModule: module, "enabled": enabled})
+	}
+
+	mm.refreshModuleEnabledMetric()
+}
+
+func (mm *ModuleManager) refreshModuleEnabledMetric() {
+	mm.dependencies.MetricStorage.Grouped().ExpireGroupMetrics(moduleEnabledMetricGroup)
+
+	for _, name := range mm.GetModuleNames() {
+		if !mm.IsModuleEnabled(name) {
+			continue
+		}
+
+		mod := mm.GetModule(name)
+		if mod == nil {
+			continue
+		}
+
+		version := mod.GetVersion()
+		if version == "" {
+			continue
+		}
+
+		labels := map[string]string{
+			pkg.MetricKeyModule:  name,
+			pkg.MetricKeyVersion: version,
+		}
+		mm.dependencies.MetricStorage.Grouped().GaugeSet(moduleEnabledMetricGroup, metrics.ModuleEnabledMetricName, 1, labels)
+		// Telemetry twin: same gauge under the d8_telemetry_ prefix so
+		// flant-integration ships it to DOP. Kept in the same group so
+		// ExpireGroupMetrics above wipes both copies in lockstep.
+		mm.dependencies.MetricStorage.Grouped().GaugeSet(moduleEnabledMetricGroup, metrics.ModuleEnabledTelemetryMetricName, 1, labels)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

Add `BasicModule.SetVersion` / `GetVersion` and emit two gauges with
`{module, version}` labels from `UpdateModulesMetrics`:

- `{PREFIX}mm_module_enabled` — local metric.
- `d8_telemetry_module_enabled` — picked up by `flant-integration` and shipped to DOP.

#### What this PR does / why we need it

Flant needs per-cluster visibility into deployed module versions (kubeall dashboard).
DOP ingests only `d8_telemetry_*`.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

