### PR TITLE
[fix] ensure consistent hook sorting by name

### DIFF
--- a/pkg/module_manager/models/modules/hook_storage.go
+++ b/pkg/module_manager/models/modules/hook_storage.go
@@ -47,7 +47,12 @@ func (hs *HooksStorage) getHooks(bt ...sh_op_types.BindingType) []*hooks.ModuleH
 			return []*hooks.ModuleHook{}
 		}
 		sort.Slice(res, func(i, j int) bool {
-			return res[i].Order(t) < res[j].Order(t)
+			oi, oj := res[i].Order(t), res[j].Order(t)
+			if oi != oj {
+				return oi < oj
+			}
+
+			return res[i].GetName() < res[j].GetName()
 		})
 
 		return res


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
Improve hook sorting by adding a secondary sort criterion based on hook names when orders are equal. This ensures consistent ordering of hooks with the same order value.
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
Hooks with the same Order value were executed in a non-deterministic order. This matters because an earlier hook can perform a check and set a value, allowing subsequent hooks to skip the check and simply read that value — but this pattern breaks when execution order is unpredictable.
The fix adds a secondary sort by hook name when Order values are equal, so hooks with the same priority are now always executed in alphabetical order.

Before:
```bash
~ kubectl logs -n d8-system deploy/deckhouse | grep 'kubernetesSynchronization' |   grep '"module":"r-g-test"' | jq -r '.hook'

hooks/batchhooks:batch/c-test:2
hooks/batchhooks:batch/e-test:4
hooks/batchhooks:batch/f-test:5
hooks/batchhooks:batch/g-test:6
hooks/batchhooks:batch/h-test:7
hooks/batchhooks:batch/a-test:0
hooks/batchhooks:batch/d-test:3
hooks/batchhooks:batch/b-test:1
```
After:
```bash
~ kubectl logs -n d8-system deploy/deckhouse | grep 'kubernetesSynchronization' |   grep '"module":"r-g-test"' | jq -r '.hook'

hooks/batchhooks:batch/a-test:0
hooks/batchhooks:batch/b-test:1
hooks/batchhooks:batch/c-test:2
hooks/batchhooks:batch/d-test:3
hooks/batchhooks:batch/e-test:4
hooks/batchhooks:batch/f-test:5
hooks/batchhooks:batch/g-test:6
hooks/batchhooks:batch/h-test:7
```

