### PR TITLE
[fix] resolve {PREFIX} metric init order in module_manager

### DIFF
--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -51,9 +51,9 @@ import (
 )
 
 var (
-	moduleInfoMetricGroup          = "mm_module_info"
-	moduleMaintenanceMetricGroup   = "mm_module_maintenance"
-	moduleManagerServiceName       = "module-manager"
+	moduleInfoMetricGroup        = "mm_module_info"
+	moduleMaintenanceMetricGroup = "mm_module_maintenance"
+	moduleManagerServiceName     = "module-manager"
 )
 
 // ModulesState determines which modules should be enabled, disabled or reloaded.

--- a/pkg/module_manager/module_manager.go
+++ b/pkg/module_manager/module_manager.go
@@ -51,13 +51,9 @@ import (
 )
 
 var (
-	moduleInfoMetricGroup = "mm_module_info"
-	moduleInfoMetricName  = metrics.ModuleInfoMetricName
-
-	moduleMaintenanceMetricGroup = "mm_module_maintenance"
-	moduleMaintenanceMetricName  = metrics.ModuleMaintenanceMetricName
-
-	moduleManagerServiceName = "module-manager"
+	moduleInfoMetricGroup          = "mm_module_info"
+	moduleMaintenanceMetricGroup   = "mm_module_maintenance"
+	moduleManagerServiceName       = "module-manager"
 )
 
 // ModulesState determines which modules should be enabled, disabled or reloaded.
@@ -294,7 +290,7 @@ func (mm *ModuleManager) validateNewKubeConfig(kubeConfig *config.KubeConfig, al
 		if moduleConfig.GetMaintenanceState() == utils.NoResourceReconciliation {
 			mm.dependencies.MetricStorage.Grouped().GaugeSet(
 				moduleMaintenanceMetricGroup,
-				moduleMaintenanceMetricName,
+				metrics.ModuleMaintenanceMetricName,
 				1,
 				map[string]string{pkg.MetricKeyModule: moduleName, "state": utils.NoResourceReconciliation.String()},
 			)
@@ -507,7 +503,7 @@ func (mm *ModuleManager) SetGlobalDiscoveryAPIVersions(apiVersions []string) {
 
 // UpdateModulesMetrics updates modules' states metrics
 func (mm *ModuleManager) UpdateModulesMetrics() {
-	mm.dependencies.MetricStorage.Grouped().ExpireGroupMetricByName(moduleInfoMetricGroup, moduleInfoMetricName)
+	mm.dependencies.MetricStorage.Grouped().ExpireGroupMetricByName(moduleInfoMetricGroup, metrics.ModuleInfoMetricName)
 
 	for _, module := range mm.GetModuleNames() {
 		enabled := "false"
@@ -515,7 +511,7 @@ func (mm *ModuleManager) UpdateModulesMetrics() {
 			enabled = "true"
 		}
 
-		mm.dependencies.MetricStorage.Grouped().GaugeSet(moduleInfoMetricGroup, moduleInfoMetricName, 1, map[string]string{pkg.MetricKeyModule: module, "enabled": enabled})
+		mm.dependencies.MetricStorage.Grouped().GaugeSet(moduleInfoMetricGroup, metrics.ModuleInfoMetricName, 1, map[string]string{pkg.MetricKeyModule: module, "enabled": enabled})
 	}
 }
 
@@ -527,9 +523,9 @@ func (mm *ModuleManager) SetModuleMaintenanceState(moduleName string, state util
 			slog.String(pkg.LogKeyState, state.String()))
 
 		if state == utils.NoResourceReconciliation {
-			mm.dependencies.MetricStorage.Grouped().GaugeSet(moduleMaintenanceMetricGroup, moduleMaintenanceMetricName, 1, map[string]string{pkg.MetricKeyModule: moduleName, "state": utils.NoResourceReconciliation.String()})
+			mm.dependencies.MetricStorage.Grouped().GaugeSet(moduleMaintenanceMetricGroup, metrics.ModuleMaintenanceMetricName, 1, map[string]string{pkg.MetricKeyModule: moduleName, "state": utils.NoResourceReconciliation.String()})
 		} else {
-			mm.dependencies.MetricStorage.Grouped().ExpireGroupMetricByName(moduleMaintenanceMetricGroup, moduleMaintenanceMetricName)
+			mm.dependencies.MetricStorage.Grouped().ExpireGroupMetricByName(moduleMaintenanceMetricGroup, metrics.ModuleMaintenanceMetricName)
 		}
 	}
 }


### PR DESCRIPTION
#### Overview

Fix `{PREFIX}` placeholder not being replaced in two addon-operator metrics (`mm_module_info` and `mm_module_maintenance`), causing them to appear as `_PREFIX_mm_*` in Prometheus instead of `deckhouse_mm_*`.

#### What this PR does / why we need it

Package-level variables `moduleInfoMetricName` and `moduleMaintenanceMetricName` in `module_manager.go` copied metric names from the `metrics` package at Go init time, before `InitMetrics()` could replace the `{PREFIX}` placeholder. At call sites, these stale copies were used instead of the updated `metrics.ModuleInfoMetricName` / `metrics.ModuleMaintenanceMetricName`.

This caused the `ModuleIsInMaintenanceMode` Prometheus alert to never fire, because the alert expression referenced `deckhouse_mm_module_maintenance` while the actual metric was exported as `_PREFIX_mm_module_maintenance`.

The fix removes the two package-level variable copies and reads directly from `metrics.ModuleInfoMetricName` / `metrics.ModuleMaintenanceMetricName` at call time, after `InitMetrics()` has already replaced the prefix.

#### Special notes for your reviewer

Verified in a staging Deckhouse cluster — before the fix, only `_PREFIX_mm_module_maintenance` and `_PREFIX_mm_module_info` were present; all other metrics correctly used the `deckhouse_` prefix.
