### PR TITLE
feat(validation): add oldSelf support to x-deckhouse-validations CEL rules

### DIFF
--- a/pkg/module_manager/models/modules/values_storage.go
+++ b/pkg/module_manager/models/modules/values_storage.go
@@ -118,18 +118,36 @@ func (vs *ValuesStorage) calculateResultValues() error {
 	return nil
 }
 
+// validateConfigValues validates values against the config OpenAPI schema.
+// Previously stored user settings are passed as the old state so that
+// x-deckhouse-validations transition rules (rules referencing oldSelf) can
+// implement immutability and other update-time invariants on ModuleConfig.
 func (vs *ValuesStorage) validateConfigValues(values utils.Values) error {
 	valuesModuleName := utils.ModuleNameToValuesKey(vs.moduleName)
 	validatableValues := utils.Values{valuesModuleName: values}
 
-	return vs.schemaStorage.ValidateConfigValues(valuesModuleName, validatableValues)
+	var oldValidatable utils.Values
+	if vs.configValues != nil {
+		oldValidatable = utils.Values{valuesModuleName: utils.Values(vs.configValues)}
+	}
+
+	return vs.schemaStorage.ValidateConfigValuesTransition(valuesModuleName, validatableValues, oldValidatable)
 }
 
+// validateValues validates values against the values OpenAPI schema.
+// Previously merged result values are passed as the old state so that
+// x-deckhouse-validations transition rules (rules referencing oldSelf) can
+// catch attempts to mutate immutable fields via values patches.
 func (vs *ValuesStorage) validateValues(values utils.Values) error {
 	valuesModuleName := utils.ModuleNameToValuesKey(vs.moduleName)
 	validatableValues := utils.Values{valuesModuleName: values}
 
-	return vs.schemaStorage.ValidateValues(valuesModuleName, validatableValues)
+	var oldValidatable utils.Values
+	if vs.resultValues != nil {
+		oldValidatable = utils.Values{valuesModuleName: utils.Values(vs.resultValues)}
+	}
+
+	return vs.schemaStorage.ValidateValuesTransition(valuesModuleName, validatableValues, oldValidatable)
 }
 
 // applyNewSchemaStorage sets new schema storage

--- a/pkg/module_manager/models/modules/values_storage.go
+++ b/pkg/module_manager/models/modules/values_storage.go
@@ -128,7 +128,7 @@ func (vs *ValuesStorage) validateConfigValues(values utils.Values) error {
 
 	var oldValidatable utils.Values
 	if vs.configValues != nil {
-		oldValidatable = utils.Values{valuesModuleName: utils.Values(vs.configValues)}
+		oldValidatable = utils.Values{valuesModuleName: vs.configValues}
 	}
 
 	return vs.schemaStorage.ValidateConfigValuesTransition(valuesModuleName, validatableValues, oldValidatable)
@@ -144,7 +144,7 @@ func (vs *ValuesStorage) validateValues(values utils.Values) error {
 
 	var oldValidatable utils.Values
 	if vs.resultValues != nil {
-		oldValidatable = utils.Values{valuesModuleName: utils.Values(vs.resultValues)}
+		oldValidatable = utils.Values{valuesModuleName: vs.resultValues}
 	}
 
 	return vs.schemaStorage.ValidateValuesTransition(valuesModuleName, validatableValues, oldValidatable)

--- a/pkg/values/validation/cel/cel.go
+++ b/pkg/values/validation/cel/cel.go
@@ -64,21 +64,26 @@ func ValidateTransition(schema *spec.Schema, values, oldValues any) ([]error, er
 	// corresponding old value (if any) so transition rules can fire at any depth.
 	if m, ok := values.(map[string]any); ok {
 		oldMap, _ := oldValues.(map[string]any)
+
 		for propName, propSchema := range schema.Properties {
 			propValue, ok := m[propName]
 			if !ok {
 				continue
 			}
+
 			var oldPropValue any
+
 			if oldMap != nil {
 				if v, found := oldMap[propName]; found {
 					oldPropValue = v
 				}
 			}
+
 			subErrs, err := ValidateTransition(&propSchema, propValue, oldPropValue)
 			if err != nil {
 				return nil, err
 			}
+
 			validationErrs = append(validationErrs, subErrs...)
 		}
 	}
@@ -129,6 +134,7 @@ func ValidateTransition(schema *spec.Schema, values, oldValues any) ([]error, er
 	// oldSelf are skipped instead of being evaluated against an undefined value.
 	haveOld := oldValues != nil
 	celOldSelfType := cel.DynType
+
 	var celOldSelfValue any
 	if haveOld {
 		celOldSelfType, celOldSelfValue, err = buildCELValueAndType(oldValues)
@@ -194,13 +200,16 @@ func expressionUsesOldSelf(ast *cel.Ast) bool {
 	if ast == nil {
 		return false
 	}
+
 	rep := ast.NativeRep()
 	if rep == nil {
 		return false
 	}
+
 	matches := celast.MatchDescendants(celast.NavigateAST(rep), func(e celast.NavigableExpr) bool {
 		return e.Kind() == celast.IdentKind && e.AsIdent() == oldSelfVar
 	})
+
 	return len(matches) > 0
 }
 

--- a/pkg/values/validation/cel/cel.go
+++ b/pkg/values/validation/cel/cel.go
@@ -7,30 +7,79 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/google/cel-go/cel"
+	celast "github.com/google/cel-go/common/ast"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// ruleKey is the OpenAPI extension key that carries CEL validation rules for Deckhouse schemas.
 const ruleKey = "x-deckhouse-validations"
 
+// selfVar / oldSelfVar are the CEL variable names exposed to expressions.
+// selfVar holds the current value at the schema level being evaluated;
+// oldSelfVar holds the corresponding previous value (e.g. the previously
+// stored ModuleConfig settings) and powers transition rules / immutability checks.
+const (
+	selfVar    = "self"
+	oldSelfVar = "oldSelf"
+)
+
+// rule is a single CEL validation entry in an x-deckhouse-validations extension list.
+// Expression is a CEL expression over "self" (and optionally "oldSelf");
+// Message is returned when the expression is false.
 type rule struct {
 	Expression string `json:"expression" yaml:"expression"`
 	Message    string `json:"message" yaml:"message"`
 }
 
-// Validate validates config values against x-deckhouse-validation rules in schema
+// Validate evaluates all x-deckhouse-validations CEL rules attached to schema and
+// its nested properties recursively without any previous-value context. Rules
+// that reference oldSelf (transition rules) are skipped.
+//
+// It is equivalent to ValidateTransition(schema, values, nil) and is preserved
+// as a thin wrapper for callers that don't have access to the previous values.
 func Validate(schema *spec.Schema, values any) ([]error, error) {
-	var validationErrs []error
-	// First we validate only object nested properties
-	if m, ok := values.(map[string]any); ok {
-		for propName, propSchema := range schema.Properties {
-			if propValue, ok := m[propName]; ok {
-				subErrs, err := Validate(&propSchema, propValue)
-				if err != nil {
-					return nil, err
-				}
+	return ValidateTransition(schema, values, nil)
+}
 
-				validationErrs = append(validationErrs, subErrs...)
+// ValidateTransition evaluates all x-deckhouse-validations CEL rules attached to
+// schema and its nested properties recursively, exposing the current value as
+// "self" and the previous value as "oldSelf" inside expressions.
+//
+// Rules referencing oldSelf are treated as transition rules: they are
+// evaluated only when an old value is available at the same level (i.e. on
+// updates) and silently skipped otherwise (e.g. on create or for newly added
+// properties). This mirrors the semantics of x-kubernetes-validations and
+// allows expressing immutability with a rule like:
+//
+//	x-deckhouse-validations:
+//	  - expression: "self == oldSelf"
+//	    message: "field is immutable"
+//
+// It returns validation errors for every rule that evaluated to false, and a
+// non-nil error for configuration or evaluation failures.
+func ValidateTransition(schema *spec.Schema, values, oldValues any) ([]error, error) {
+	var validationErrs []error
+
+	// First we validate only object nested properties, threading the
+	// corresponding old value (if any) so transition rules can fire at any depth.
+	if m, ok := values.(map[string]any); ok {
+		oldMap, _ := oldValues.(map[string]any)
+		for propName, propSchema := range schema.Properties {
+			propValue, ok := m[propName]
+			if !ok {
+				continue
 			}
+			var oldPropValue any
+			if oldMap != nil {
+				if v, found := oldMap[propName]; found {
+					oldPropValue = v
+				}
+			}
+			subErrs, err := ValidateTransition(&propSchema, propValue, oldPropValue)
+			if err != nil {
+				return nil, err
+			}
+			validationErrs = append(validationErrs, subErrs...)
 		}
 	}
 
@@ -75,7 +124,23 @@ func Validate(schema *spec.Schema, values any) ([]error, error) {
 		return nil, err
 	}
 
-	env, err := cel.NewEnv(cel.Variable("self", celSelfType))
+	// haveOld controls transition rule evaluation at this schema level.
+	// When false (no previous value at this level), rules referencing
+	// oldSelf are skipped instead of being evaluated against an undefined value.
+	haveOld := oldValues != nil
+	celOldSelfType := cel.DynType
+	var celOldSelfValue any
+	if haveOld {
+		celOldSelfType, celOldSelfValue, err = buildCELValueAndType(oldValues)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	env, err := cel.NewEnv(
+		cel.Variable(selfVar, celSelfType),
+		cel.Variable(oldSelfVar, celOldSelfType),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create CEL env: %w", err)
 	}
@@ -86,12 +151,21 @@ func Validate(schema *spec.Schema, values any) ([]error, error) {
 			return nil, fmt.Errorf("compile the '%s' rule: %w", r.Expression, issues.Err())
 		}
 
+		// Skip transition rules when the previous value is not available
+		// at this schema level (CREATE or newly added subtree).
+		if !haveOld && expressionUsesOldSelf(ast) {
+			continue
+		}
+
 		prg, err := env.Program(ast)
 		if err != nil {
 			return nil, fmt.Errorf("create program for the '%s' rule: %w", r.Expression, err)
 		}
 
-		out, _, err := prg.Eval(map[string]any{"self": celSelfValue})
+		out, _, err := prg.Eval(map[string]any{
+			selfVar:    celSelfValue,
+			oldSelfVar: celOldSelfValue,
+		})
 		if err != nil {
 			if strings.Contains(err.Error(), "no such key:") {
 				continue
@@ -111,6 +185,23 @@ func Validate(schema *spec.Schema, values any) ([]error, error) {
 	}
 
 	return validationErrs, nil
+}
+
+// expressionUsesOldSelf reports whether the compiled CEL AST references the
+// "oldSelf" identifier anywhere in the expression tree. Used to detect
+// transition rules so they can be skipped when no previous value is available.
+func expressionUsesOldSelf(ast *cel.Ast) bool {
+	if ast == nil {
+		return false
+	}
+	rep := ast.NativeRep()
+	if rep == nil {
+		return false
+	}
+	matches := celast.MatchDescendants(celast.NavigateAST(rep), func(e celast.NavigableExpr) bool {
+		return e.Kind() == celast.IdentKind && e.AsIdent() == oldSelfVar
+	})
+	return len(matches) > 0
 }
 
 func buildCELValueAndType(value any) (*cel.Type, any, error) {

--- a/pkg/values/validation/cel/cel_test.go
+++ b/pkg/values/validation/cel/cel_test.go
@@ -1,0 +1,351 @@
+package cel
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-openapi/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// schemaFromYAML is a small test helper that mirrors how schemas are loaded
+// in production (YAML -> JSON -> spec.Schema) so that x-deckhouse-validations
+// extensions are decoded the same way as real module schemas.
+func schemaFromYAML(t *testing.T, src string) *spec.Schema {
+	t.Helper()
+
+	jsonDoc, err := yaml.YAMLToJSON([]byte(src))
+	require.NoError(t, err, "yaml to json")
+
+	s := new(spec.Schema)
+	require.NoError(t, json.Unmarshal(jsonDoc, s), "unmarshal schema")
+
+	return s
+}
+
+// valuesFromYAML decodes a YAML object into a generic map suitable for
+// passing as values / oldValues to ValidateTransition.
+func valuesFromYAML(t *testing.T, src string) map[string]any {
+	t.Helper()
+
+	jsonDoc, err := yaml.YAMLToJSON([]byte(src))
+	require.NoError(t, err, "yaml to json")
+
+	var v map[string]any
+	require.NoError(t, json.Unmarshal(jsonDoc, &v), "unmarshal values")
+
+	return v
+}
+
+// joinMessages turns a slice of validation errors into a single string for
+// concise assertions.
+func joinMessages(errs []error) []string {
+	out := make([]string, 0, len(errs))
+	for _, e := range errs {
+		out = append(out, e.Error())
+	}
+	return out
+}
+
+func TestValidate_NoRules(t *testing.T) {
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  foo:
+    type: string
+`)
+	values := valuesFromYAML(t, `foo: bar`)
+
+	errs, err := Validate(s, values)
+	require.NoError(t, err)
+	assert.Empty(t, errs)
+}
+
+func TestValidate_PlainSelfRulePass(t *testing.T) {
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  replicas:
+    type: integer
+x-deckhouse-validations:
+  - expression: "self.replicas >= 1"
+    message: "replicas must be >= 1"
+`)
+	values := valuesFromYAML(t, `replicas: 3`)
+
+	errs, err := Validate(s, values)
+	require.NoError(t, err)
+	assert.Empty(t, errs)
+}
+
+func TestValidate_PlainSelfRuleFail(t *testing.T) {
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  replicas:
+    type: integer
+x-deckhouse-validations:
+  - expression: "self.replicas >= 1"
+    message: "replicas must be >= 1"
+`)
+	values := valuesFromYAML(t, `replicas: 0`)
+
+	errs, err := Validate(s, values)
+	require.NoError(t, err)
+	require.Len(t, errs, 1)
+	assert.Equal(t, "replicas must be >= 1", errs[0].Error())
+}
+
+// ValidateTransition tests below cover the new oldSelf-aware behaviour.
+
+func TestValidateTransition_OldSelfSkippedWhenNoOldValues(t *testing.T) {
+	// A rule referencing oldSelf is a transition rule and must be skipped
+	// when no previous values are provided (e.g. on initial create).
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  clusterDomain:
+    type: string
+x-deckhouse-validations:
+  - expression: "self.clusterDomain == oldSelf.clusterDomain"
+    message: "clusterDomain is immutable"
+`)
+	values := valuesFromYAML(t, `clusterDomain: cluster.local`)
+
+	errs, err := ValidateTransition(s, values, nil)
+	require.NoError(t, err)
+	assert.Empty(t, errs, "transition rule should be skipped without oldValues")
+}
+
+func TestValidateTransition_ImmutableTopLevelFieldUnchanged(t *testing.T) {
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  clusterDomain:
+    type: string
+x-deckhouse-validations:
+  - expression: "self.clusterDomain == oldSelf.clusterDomain"
+    message: "clusterDomain is immutable"
+`)
+	values := valuesFromYAML(t, `clusterDomain: cluster.local`)
+	oldValues := valuesFromYAML(t, `clusterDomain: cluster.local`)
+
+	errs, err := ValidateTransition(s, values, oldValues)
+	require.NoError(t, err)
+	assert.Empty(t, errs)
+}
+
+func TestValidateTransition_ImmutableTopLevelFieldChanged(t *testing.T) {
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  clusterDomain:
+    type: string
+x-deckhouse-validations:
+  - expression: "self.clusterDomain == oldSelf.clusterDomain"
+    message: "clusterDomain is immutable"
+`)
+	values := valuesFromYAML(t, `clusterDomain: cluster.local`)
+	oldValues := valuesFromYAML(t, `clusterDomain: example.com`)
+
+	errs, err := ValidateTransition(s, values, oldValues)
+	require.NoError(t, err)
+	require.Len(t, errs, 1)
+	assert.Equal(t, "clusterDomain is immutable", errs[0].Error())
+}
+
+func TestValidateTransition_NestedImmutableField(t *testing.T) {
+	// Transition rules must work at any depth - oldSelf is rebound to the
+	// matching subtree of the previous values during recursion.
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  registry:
+    type: object
+    properties:
+      mode:
+        type: string
+    x-deckhouse-validations:
+      - expression: "self.mode == oldSelf.mode"
+        message: "registry.mode is immutable"
+`)
+	values := valuesFromYAML(t, `
+registry:
+  mode: Direct
+`)
+	oldValues := valuesFromYAML(t, `
+registry:
+  mode: Proxy
+`)
+
+	errs, err := ValidateTransition(s, values, oldValues)
+	require.NoError(t, err)
+	require.Len(t, errs, 1)
+	assert.Equal(t, "registry.mode is immutable", errs[0].Error())
+}
+
+func TestValidateTransition_NestedTransitionSkippedForNewlyAddedSubtree(t *testing.T) {
+	// When a nested object did not exist in the previous values, transition
+	// rules at that level must be skipped (it's effectively a create for
+	// that subtree), not fired against an undefined oldSelf.
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  registry:
+    type: object
+    properties:
+      mode:
+        type: string
+    x-deckhouse-validations:
+      - expression: "self.mode == oldSelf.mode"
+        message: "registry.mode is immutable"
+`)
+	values := valuesFromYAML(t, `
+registry:
+  mode: Direct
+`)
+	oldValues := valuesFromYAML(t, `{}`)
+
+	errs, err := ValidateTransition(s, values, oldValues)
+	require.NoError(t, err)
+	assert.Empty(t, errs, "transition rule should be skipped when subtree is new")
+}
+
+func TestValidateTransition_NonTransitionRuleStillEnforcedOnUpdate(t *testing.T) {
+	// Mixing plain rules and transition rules: plain ones still fire, even
+	// when oldValues are provided.
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  replicas:
+    type: integer
+  mode:
+    type: string
+x-deckhouse-validations:
+  - expression: "self.replicas >= 1"
+    message: "replicas must be >= 1"
+  - expression: "self.mode == oldSelf.mode"
+    message: "mode is immutable"
+`)
+	values := valuesFromYAML(t, `
+replicas: 0
+mode: Proxy
+`)
+	oldValues := valuesFromYAML(t, `
+replicas: 5
+mode: Direct
+`)
+
+	errs, err := ValidateTransition(s, values, oldValues)
+	require.NoError(t, err)
+	msgs := joinMessages(errs)
+	assert.ElementsMatch(t, []string{
+		"replicas must be >= 1",
+		"mode is immutable",
+	}, msgs)
+}
+
+func TestValidateTransition_OldSelfInComprehension(t *testing.T) {
+	// Make sure oldSelf is detected as used even when it appears inside a
+	// CEL macro/comprehension, not as a top-level identifier.
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  items:
+    type: array
+    items:
+      type: string
+x-deckhouse-validations:
+  - expression: "self.items.all(x, x in oldSelf.items)"
+    message: "items can only be appended to"
+`)
+	values := valuesFromYAML(t, `
+items: [a, b, c]
+`)
+	oldValues := valuesFromYAML(t, `
+items: [a, b]
+`)
+
+	errs, err := ValidateTransition(s, values, oldValues)
+	require.NoError(t, err)
+	require.Len(t, errs, 1)
+	assert.Equal(t, "items can only be appended to", errs[0].Error())
+}
+
+func TestValidateTransition_OldSelfMacroSkippedWithoutOld(t *testing.T) {
+	// Same expression, but no old value: it is still recognised as a
+	// transition rule (oldSelf appears in the AST) and skipped.
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  items:
+    type: array
+    items:
+      type: string
+x-deckhouse-validations:
+  - expression: "self.items.all(x, x in oldSelf.items)"
+    message: "items can only be appended to"
+`)
+	values := valuesFromYAML(t, `
+items: [a, b, c]
+`)
+
+	errs, err := ValidateTransition(s, values, nil)
+	require.NoError(t, err)
+	assert.Empty(t, errs)
+}
+
+func TestValidate_BackwardCompatibilityWithoutOldSelf(t *testing.T) {
+	// The plain Validate wrapper must keep working for schemas that don't
+	// know about oldSelf at all.
+	s := schemaFromYAML(t, `
+type: object
+properties:
+  minReplicas:
+    type: integer
+  replicas:
+    type: integer
+  maxReplicas:
+    type: integer
+x-deckhouse-validations:
+  - expression: "self.minReplicas <= self.replicas && self.replicas <= self.maxReplicas"
+    message: "replicas must be between minReplicas and maxReplicas"
+`)
+	values := valuesFromYAML(t, `
+minReplicas: 1
+replicas: 10
+maxReplicas: 5
+`)
+
+	errs, err := Validate(s, values)
+	require.NoError(t, err)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "replicas must be between")
+}
+
+func TestValidate_InvalidExtensionShape(t *testing.T) {
+	// x-deckhouse-validations must be a list of {expression, message}
+	// objects; anything else is a configuration error.
+	s := schemaFromYAML(t, `
+type: object
+x-deckhouse-validations: "not a list"
+`)
+	values := valuesFromYAML(t, `{}`)
+
+	_, err := Validate(s, values)
+	assert.Error(t, err)
+}
+
+func TestValidate_MissingExpression(t *testing.T) {
+	s := schemaFromYAML(t, `
+type: object
+x-deckhouse-validations:
+  - message: "no expression"
+`)
+	values := valuesFromYAML(t, `{}`)
+
+	_, err := Validate(s, values)
+	assert.Error(t, err)
+}

--- a/pkg/values/validation/schemas.go
+++ b/pkg/values/validation/schemas.go
@@ -88,7 +88,40 @@ func (st *SchemaStorage) ValidateValues(moduleName string, values utils.Values) 
 	return st.Validate(ValuesSchema, moduleName, values)
 }
 
+// ValidateConfigValuesTransition is like ValidateConfigValues, but additionally
+// accepts the previously stored config values so that x-deckhouse-validations
+// transition rules (rules that reference oldSelf) can fire on updates.
+// Pass oldValues=nil for the initial create / when previous values are not available.
+func (st *SchemaStorage) ValidateConfigValuesTransition(moduleName string, values, oldValues utils.Values) error {
+	return st.ValidateTransition(ConfigValuesSchema, moduleName, values, oldValues)
+}
+
+// ValidateValuesTransition is like ValidateValues, but additionally accepts
+// the previously merged result values so that x-deckhouse-validations
+// transition rules (rules that reference oldSelf) can catch attempts to mutate
+// immutable fields via values patches.
+// Pass oldValues=nil for the initial create / when previous values are not available.
+func (st *SchemaStorage) ValidateValuesTransition(moduleName string, values, oldValues utils.Values) error {
+	return st.ValidateTransition(ValuesSchema, moduleName, values, oldValues)
+}
+
+// ValidateModuleHelmValuesTransition is like ValidateModuleHelmValues, but
+// additionally accepts the previously rendered helm values so that
+// x-deckhouse-validations transition rules (rules that reference oldSelf) can
+// fire on updates.
+func (st *SchemaStorage) ValidateModuleHelmValuesTransition(moduleName string, values, oldValues utils.Values) error {
+	return st.ValidateTransition(HelmValuesSchema, moduleName, values, oldValues)
+}
+
 func (st *SchemaStorage) Validate(valuesType SchemaType, moduleName string, values utils.Values) error {
+	return st.ValidateTransition(valuesType, moduleName, values, nil)
+}
+
+// ValidateTransition is like Validate but additionally accepts the previously
+// stored values, enabling x-deckhouse-validations transition rules (rules
+// that reference oldSelf) to fire on updates. Pass oldValues=nil for the
+// initial create / when previous values are not available.
+func (st *SchemaStorage) ValidateTransition(valuesType SchemaType, moduleName string, values, oldValues utils.Values) error {
 	schema := st.Schemas[valuesType]
 	if schema == nil {
 		log.Warn("schema is not found",
@@ -103,7 +136,14 @@ func (st *SchemaStorage) Validate(valuesType SchemaType, moduleName string, valu
 		return fmt.Errorf("root key '%s' not found in input values", moduleName)
 	}
 
-	validationErr := validateObject(obj, schema, moduleName)
+	var oldObj interface{}
+	if oldValues != nil {
+		if v, found := oldValues[moduleName]; found {
+			oldObj = v
+		}
+	}
+
+	validationErr := validateObject(obj, oldObj, schema, moduleName)
 	if validationErr == nil {
 		log.Debug("values are valid",
 			slog.String(pkg.LogKeyValuesType, string(valuesType)))
@@ -117,8 +157,10 @@ func (st *SchemaStorage) Validate(valuesType SchemaType, moduleName string, valu
 }
 
 // validateObject uses schema to validate data structure in the dataObj.
+// oldDataObj is the previous value (or nil) and is threaded into CEL transition
+// rules (rules that reference oldSelf in x-deckhouse-validations).
 // See https://github.com/kubernetes/apiextensions-apiserver/blob/1bb376f70aa2c6f2dec9a8c7f05384adbfac7fbb/pkg/apiserver/validation/validation.go#L47
-func validateObject(dataObj interface{}, s *spec.Schema, rootName string) error {
+func validateObject(dataObj, oldDataObj interface{}, s *spec.Schema, rootName string) error {
 	if s == nil {
 		return fmt.Errorf("validate config: schema is not provided")
 	}
@@ -136,9 +178,17 @@ func validateObject(dataObj interface{}, s *spec.Schema, rootName string) error 
 		return fmt.Errorf("validated data object have to be utils.Values or map[string]interface{}, got %v instead", reflect.TypeOf(v))
 	}
 
-	// Validate values against x-deckhouse-validation rules.
+	// Normalize the optional old value: utils.Values is just a typed alias
+	// for map[string]interface{}, but cel.ValidateTransition expects the
+	// untyped map so it can recurse uniformly.
+	if v, ok := oldDataObj.(utils.Values); ok {
+		oldDataObj = map[string]interface{}(v)
+	}
+
+	// Validate values against x-deckhouse-validation rules, threading the
+	// previous values so transition rules (oldSelf) can be evaluated.
 	if values, ok := dataObj.(map[string]interface{}); ok {
-		validationErrs, err := cel.Validate(s, values)
+		validationErrs, err := cel.ValidateTransition(s, values, oldDataObj)
 		if err != nil {
 			return err
 		}

--- a/pkg/values/validation/schemas.go
+++ b/pkg/values/validation/schemas.go
@@ -137,6 +137,7 @@ func (st *SchemaStorage) ValidateTransition(valuesType SchemaType, moduleName st
 	}
 
 	var oldObj interface{}
+
 	if oldValues != nil {
 		if v, found := oldValues[moduleName]; found {
 			oldObj = v


### PR DESCRIPTION
## Summary

Adds `oldSelf` transition-rule support to `x-deckhouse-validations` CEL expressions, mirroring the semantics of `x-kubernetes-validations` in Kubernetes CRD validation.

Previously, CEL rules in module schemas could only inspect the current value (`self`). This change threads the previous value through the entire validation stack so that rules can also reference `oldSelf` to implement update-time invariants — most notably immutability constraints on `ModuleConfig` fields.

## Changes

### `pkg/values/validation/cel/cel.go`
- Renamed `Validate` to a thin wrapper; introduced `ValidateTransition(schema, values, oldValues)` as the main entry point.
- `oldSelf` is bound as a CEL variable at each schema level and resolved recursively by matching property names in the old value map.
- Rules that reference `oldSelf` are detected via AST traversal (`expressionUsesOldSelf`) and **skipped** when no previous value exists at that schema level (create path or newly added subtrees). This prevents `oldSelf`-referencing rules from failing on initial creation.

### `pkg/values/validation/schemas.go`
- Added `ValidateTransition`, `ValidateConfigValuesTransition`, `ValidateValuesTransition`, and `ValidateModuleHelmValuesTransition` on `SchemaStorage`.
- `Validate` now delegates to `ValidateTransition(…, nil)`, keeping all existing callers working without changes.
- `validateObject` accepts an optional `oldDataObj` and passes it to `cel.ValidateTransition`.

### `pkg/module_manager/models/modules/values_storage.go`
- `validateConfigValues` now calls `ValidateConfigValuesTransition`, passing the currently stored `configValues` as the old state.
- `validateValues` now calls `ValidateValuesTransition`, passing the currently merged `resultValues` as the old state.

### `pkg/values/validation/cel/cel_test.go` (new)
Full test suite covering:
- No rules / plain rules (no regression)
- `oldSelf`-only rules skipped on create
- `oldSelf` rules fire correctly on update
- Nested immutable field enforcement
- Newly added subtree treated as create (transition skipped)
- Mixed plain + transition rules
- `oldSelf` inside CEL macros/comprehensions (e.g. `all(x, x in oldSelf.items)`)
- Backward compatibility via the `Validate` wrapper

## Usage example

```yaml
x-deckhouse-validations:
  - expression: "self.mode == oldSelf.mode"
    message: "mode is immutable after creation"
```