### PR TITLE
[addon-operator] bump module-sdk to v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/deckhouse/deckhouse/pkg/log v0.2.1
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0
-	github.com/deckhouse/module-sdk v0.11.2-0.20260710094941-9055735d87f9
+	github.com/deckhouse/module-sdk v0.12.0
 	github.com/dominikbraun/graph v0.23.0
 	github.com/ettle/strcase v0.2.0
 	github.com/flant/kube-client v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/deckhouse/deckhouse/pkg/log v0.2.1 h1:7SSD+QJPnziAO3l8ycgRwN5wlQeC312
 github.com/deckhouse/deckhouse/pkg/log v0.2.1/go.mod h1:pbAxTSDcPmwyl3wwKDcEB3qdxHnRxqTV+J0K+sha8bw=
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 h1:xZvbKuexrSQGEw6CB4n3UC7XbOb9QNLbm8UhcGZ2R1I=
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0/go.mod h1:Rz++SzCLkFW03WGgftnn91TimGU2shiKb5S/YuxcBuE=
-github.com/deckhouse/module-sdk v0.11.2-0.20260710094941-9055735d87f9 h1:Cpp84MXlYXTdjlIheN0dzCv2dc8BhPeCACB0DVDVcak=
-github.com/deckhouse/module-sdk v0.11.2-0.20260710094941-9055735d87f9/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
+github.com/deckhouse/module-sdk v0.12.0 h1:kQe0RmhHz3+A2VoxG56/8Dd4WeVSbwc38Ocg3Can16g=
+github.com/deckhouse/module-sdk v0.12.0/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=


### PR DESCRIPTION
Bumps `module-sdk` from the temporary feature-branch pseudo-version to the released **v0.12.0**.

#754 (beforeDeleteHelm binding) was merged just before module-sdk #104 was released, so `main` was left pinning `v0.11.2-0.20260710094941-9055735d87f9` (an unreleased feature-branch commit) instead of the proper release. v0.12.0 contains the `OnBeforeDeleteHelm` binding and is the squash-merge of module-sdk #104.

Build and hook tests pass.