### PR TITLE
[addon-operator] propagate module context to nelm logs

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -102,6 +102,8 @@ func InitHelmClientFactory(helmopts *Options, labels map[string]string) (*Client
 			return nil, fmt.Errorf("init helm3lib for nelm fallback: %w", err)
 		}
 
+		nelm.InitDefaultLogger(helmopts.Logger)
+
 		factory.NewClientFn = func(logger *log.Logger, labels map[string]string) client.HelmClient {
 			opts := &nelm.CommonOptions{
 				HistoryMax:  helmopts.HistoryMax,

--- a/pkg/helm/nelm/logger.go
+++ b/pkg/helm/nelm/logger.go
@@ -24,73 +24,81 @@ type NelmLogger struct {
 	logger *log.Logger
 }
 
+func (n *NelmLogger) moduleAttr(ctx context.Context) []any {
+	if m := moduleFromContext(ctx); m != "" {
+		return []any{slog.String(pkg.LogKeyModule, m)}
+	}
+
+	return nil
+}
+
 func (n *NelmLogger) Trace(ctx context.Context, format string, a ...interface{}) {
-	n.logger.Log(ctx, log.LevelTrace.Level(), fmt.Sprintf(format, a...))
+	n.logger.Log(ctx, log.LevelTrace.Level(), fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) TraceStruct(ctx context.Context, obj interface{}, format string, a ...interface{}) {
-	n.logger.Log(ctx, log.LevelTrace.Level(), fmt.Sprintf(format, a...), slog.Any(pkg.LogKeyObj, obj))
+	n.logger.Log(ctx, log.LevelTrace.Level(), fmt.Sprintf(format, a...), append(n.moduleAttr(ctx), slog.Any(pkg.LogKeyObj, obj))...)
 }
 
 func (n *NelmLogger) TracePush(ctx context.Context, _, format string, a ...interface{}) {
-	n.logger.Log(ctx, log.LevelTrace.Level(), fmt.Sprintf(format, a...))
+	n.logger.Log(ctx, log.LevelTrace.Level(), fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) TracePop(_ context.Context, _ string) {
 }
 
 func (n *NelmLogger) Debug(ctx context.Context, format string, a ...interface{}) {
-	n.logger.DebugContext(ctx, fmt.Sprintf(format, a...))
+	n.logger.DebugContext(ctx, fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) DebugPush(ctx context.Context, _, format string, a ...interface{}) {
-	n.logger.DebugContext(ctx, fmt.Sprintf(format, a...))
+	n.logger.DebugContext(ctx, fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) DebugPop(_ context.Context, _ string) {
 }
 
 func (n *NelmLogger) Info(ctx context.Context, format string, a ...interface{}) {
-	n.logger.InfoContext(ctx, fmt.Sprintf(format, a...))
+	n.logger.InfoContext(ctx, fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) InfoPush(ctx context.Context, _, format string, a ...interface{}) {
-	n.logger.InfoContext(ctx, fmt.Sprintf(format, a...))
+	n.logger.InfoContext(ctx, fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) InfoPop(_ context.Context, _ string) {
 }
 
 func (n *NelmLogger) Warn(ctx context.Context, format string, a ...interface{}) {
-	n.logger.WarnContext(ctx, fmt.Sprintf(format, a...))
+	n.logger.WarnContext(ctx, fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) WarnPush(ctx context.Context, _, format string, a ...interface{}) {
-	n.logger.WarnContext(ctx, fmt.Sprintf(format, a...))
+	n.logger.WarnContext(ctx, fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) WarnPop(_ context.Context, _ string) {
 }
 
 func (n *NelmLogger) Error(ctx context.Context, format string, a ...interface{}) {
-	n.logger.ErrorContext(ctx, fmt.Sprintf(format, a...))
+	n.logger.ErrorContext(ctx, fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) ErrorPush(ctx context.Context, _, format string, a ...interface{}) {
-	n.logger.ErrorContext(ctx, fmt.Sprintf(format, a...))
+	n.logger.ErrorContext(ctx, fmt.Sprintf(format, a...), n.moduleAttr(ctx)...)
 }
 
 func (n *NelmLogger) ErrorPop(_ context.Context, _ string) {
 }
 
 func (n *NelmLogger) InfoBlock(ctx context.Context, opts nelmlog.BlockOptions, fn func()) {
-	n.logger.InfoContext(ctx, opts.BlockTitle)
+	n.logger.InfoContext(ctx, opts.BlockTitle, n.moduleAttr(ctx)...)
 
 	fn()
 }
 
 func (n *NelmLogger) InfoBlockErr(ctx context.Context, opts nelmlog.BlockOptions, fn func() error) error {
-	n.logger.InfoContext(ctx, opts.BlockTitle)
+	n.logger.InfoContext(ctx, opts.BlockTitle, n.moduleAttr(ctx)...)
 
 	return fmt.Errorf("inner func err: %w", fn())
 }

--- a/pkg/helm/nelm/nelm.go
+++ b/pkg/helm/nelm/nelm.go
@@ -39,6 +39,30 @@ var (
 	one sync.Once
 )
 
+type moduleCtxKey struct{}
+
+func contextWithModule(ctx context.Context, module string) context.Context {
+	if module == "" {
+		return ctx
+	}
+
+	return context.WithValue(ctx, moduleCtxKey{}, module)
+}
+
+func moduleFromContext(ctx context.Context) string {
+	if m, ok := ctx.Value(moduleCtxKey{}).(string); ok {
+		return m
+	}
+
+	return ""
+}
+
+func InitDefaultLogger(logger *log.Logger) {
+	one.Do(func() {
+		nelmLog.Default = newNelmLogger(logger.Named("nelm").With(slog.String(pkg.LogKeyOperatorComponent, "nelm")))
+	})
+}
+
 type CommonOptions struct {
 	genericclioptions.ConfigFlags
 
@@ -179,11 +203,6 @@ func (s *SafeNelmActions) ChartRender(ctx context.Context, opts action.ChartRend
 }
 
 func NewNelmClient(opts *CommonOptions, logger *log.Logger, labels map[string]string) *NelmClient {
-	// singleton
-	one.Do(func() {
-		nelmLog.Default = newNelmLogger(logger)
-	})
-
 	if opts == nil {
 		opts = &CommonOptions{}
 	}
@@ -233,7 +252,9 @@ type NelmClient struct {
 
 // GetReleaseLabels returns a specific label value from the release.
 func (c *NelmClient) GetReleaseLabels(releaseName, labelName string) (string, error) {
-	releaseGetResult, err := c.actions.ReleaseGet(context.TODO(), releaseName, *c.opts.Namespace, action.ReleaseGetOptions{
+	ctx := contextWithModule(context.Background(), releaseName)
+
+	releaseGetResult, err := c.actions.ReleaseGet(ctx, releaseName, *c.opts.Namespace, action.ReleaseGetOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.opts.KubeContext,
 		},
@@ -290,7 +311,9 @@ func (c *NelmClient) GetAnnotations() map[string]string {
 }
 
 func (c *NelmClient) LastReleaseStatus(releaseName string) (string, string, error) {
-	releaseGetResult, err := c.actions.ReleaseGet(context.TODO(), releaseName, *c.opts.Namespace, action.ReleaseGetOptions{
+	ctx := contextWithModule(context.Background(), releaseName)
+
+	releaseGetResult, err := c.actions.ReleaseGet(ctx, releaseName, *c.opts.Namespace, action.ReleaseGetOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.opts.KubeContext,
 		},
@@ -318,6 +341,8 @@ func (c *NelmClient) UpgradeRelease(releaseName, modulePath string, valuesPaths 
 
 	logger.Info("Running nelm upgrade for release")
 
+	ctx := contextWithModule(context.Background(), releaseName)
+
 	// Add client annotations
 	extraAnnotations := make(map[string]string)
 	if c.annotations != nil {
@@ -331,7 +356,7 @@ func (c *NelmClient) UpgradeRelease(releaseName, modulePath string, valuesPaths 
 	}
 
 	// First check if release exists
-	_, err := c.actions.ReleaseGet(context.Background(), releaseName, namespace, action.ReleaseGetOptions{
+	_, err := c.actions.ReleaseGet(ctx, releaseName, namespace, action.ReleaseGetOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.opts.KubeContext,
 		},
@@ -361,7 +386,7 @@ func (c *NelmClient) UpgradeRelease(releaseName, modulePath string, valuesPaths 
 		installGraphPath = filepath.Join(graphDir, graphFile)
 	}
 
-	if err := c.actions.ReleaseInstall(context.TODO(), releaseName, namespace, action.ReleaseInstallOptions{
+	if err := c.actions.ReleaseInstall(ctx, releaseName, namespace, action.ReleaseInstallOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.opts.KubeContext,
 		},
@@ -403,7 +428,9 @@ func (c *NelmClient) UpgradeRelease(releaseName, modulePath string, valuesPaths 
 }
 
 func (c *NelmClient) GetReleaseValues(releaseName string) (utils.Values, error) {
-	releaseGetResult, err := c.actions.ReleaseGet(context.TODO(), releaseName, *c.opts.Namespace, action.ReleaseGetOptions{
+	ctx := contextWithModule(context.Background(), releaseName)
+
+	releaseGetResult, err := c.actions.ReleaseGet(ctx, releaseName, *c.opts.Namespace, action.ReleaseGetOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.opts.KubeContext,
 		},
@@ -434,7 +461,9 @@ func (c *NelmClient) GetReleaseValues(releaseName string) (utils.Values, error) 
 func (c *NelmClient) GetReleaseChecksum(releaseName string) (string, error) {
 	logger := c.logger.With(slog.String(pkg.LogKeyReleaseName, releaseName))
 
-	releaseGetResult, err := c.actions.ReleaseGet(context.TODO(), releaseName, *c.opts.Namespace, action.ReleaseGetOptions{
+	ctx := contextWithModule(context.Background(), releaseName)
+
+	releaseGetResult, err := c.actions.ReleaseGet(ctx, releaseName, *c.opts.Namespace, action.ReleaseGetOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.opts.KubeContext,
 		},
@@ -479,7 +508,9 @@ func (c *NelmClient) DeleteRelease(releaseName string) error {
 		installGraphPath = filepath.Join(graphDir, graphFile)
 	}
 
-	if err := c.actions.ReleaseUninstall(context.TODO(), releaseName, *c.opts.Namespace, action.ReleaseUninstallOptions{
+	ctx := contextWithModule(context.Background(), releaseName)
+
+	if err := c.actions.ReleaseUninstall(ctx, releaseName, *c.opts.Namespace, action.ReleaseUninstallOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.opts.KubeContext,
 		},
@@ -566,7 +597,9 @@ func (c *NelmClient) Render(releaseName, modulePath string, valuesPaths, setValu
 		extraAnnotations["maintenance.deckhouse.io/no-resource-reconciliation"] = ""
 	}
 
-	chartRenderResult, err := c.actions.ChartRender(context.TODO(), action.ChartRenderOptions{
+	ctx := contextWithModule(context.Background(), releaseName)
+
+	chartRenderResult, err := c.actions.ChartRender(ctx, action.ChartRenderOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.opts.KubeContext,
 		},

--- a/pkg/helm/nelm/nelm_test.go
+++ b/pkg/helm/nelm/nelm_test.go
@@ -1,20 +1,46 @@
 package nelm
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/stretchr/testify/assert"
 	nelmLog "github.com/werf/nelm/pkg/log"
+
+	"github.com/flant/addon-operator/pkg"
 )
 
 func Test_NewNelmClient(t *testing.T) {
-	logger := log.NewNop()
-	cl := NewNelmClient(&CommonOptions{}, logger.Named("nelm"), map[string]string{})
-	assert.NotNil(t, cl)
+	InitDefaultLogger(log.NewNop())
 	singleLogger := nelmLog.Default
 
-	logger2 := log.NewNop()
-	_ = NewNelmClient(&CommonOptions{}, logger2.Named("test"), map[string]string{})
-	assert.Equal(t, singleLogger, nelmLog.Default) // logger has not changed
+	cl := NewNelmClient(&CommonOptions{}, log.NewNop().Named("nelm"), map[string]string{})
+	assert.NotNil(t, cl)
+	assert.Equal(t, singleLogger, nelmLog.Default, "NewNelmClient must not override the global nelm logger")
+
+	InitDefaultLogger(log.NewNop())
+	assert.Equal(t, singleLogger, nelmLog.Default, "InitDefaultLogger must set the global nelm logger only once")
+}
+
+func Test_NelmLogger_ModuleFromContext(t *testing.T) {
+	buf := &bytes.Buffer{}
+	nl := newNelmLogger(log.NewLogger(log.WithOutput(buf)))
+
+	nl.Info(contextWithModule(context.Background(), "node-manager"), "progress for %s", "node-manager")
+
+	var entry map[string]any
+	assert.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &entry))
+	assert.Equal(t, "node-manager", entry[pkg.LogKeyModule])
+	assert.Equal(t, "progress for node-manager", entry["msg"])
+
+	buf.Reset()
+	nl.Info(context.Background(), "no module here")
+
+	var neutral map[string]any
+	assert.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &neutral))
+	_, hasModule := neutral[pkg.LogKeyModule]
+	assert.False(t, hasModule, "module must be absent when context has no module")
 }


### PR DESCRIPTION
#### Overview

Propagate the module name into the nelm logger context so nelm log lines for release operations carry a `module` attribute and can be filtered by module.

#### What this PR does / why we need it

Nelm client calls (`ReleaseGet`/`ReleaseInstall`/`ReleaseUninstall`/`ChartRender`) in `pkg/helm/nelm/nelm.go` were passing `context.TODO()` / `context.Background()`, so the nelm logger never had a `module` attribute for these operations, making it impossible to filter nelm logs by module.

Changes:
- `pkg/helm/nelm/nelm.go`
  - Add private `moduleCtxKey` with helpers `contextWithModule(ctx, module)` / `moduleFromContext(ctx)`.
  - Propagate a context carrying the release name as module in all `NelmClient` methods: `GetReleaseLabels`, `LastReleaseStatus`, `UpgradeRelease`, `GetReleaseValues`, `GetReleaseChecksum`, `DeleteRelease`, `Render`.
  - Move global `nelmLog.Default` init out of `NewNelmClient` into exported `InitDefaultLogger(logger)` guarded by `sync.Once`, so the global logger is set once at startup rather than lazily on first client construction.
- `pkg/helm/nelm/logger.go`
  - Add `NelmLogger.moduleAttr(ctx)` returning `slog.String(pkg.LogKeyModule, m)` when a module is present in the context; append it to all `Trace`/`Debug`/`Info`/`Warn`/`Error`/`*Push`/`InfoBlock*` methods.
- `pkg/helm/helm.go`
  - Call `nelm.InitDefaultLogger(helmopts.Logger)` once in `InitHelmClientFactory` for the `Nelm` backend.
- `pkg/helm/nelm/nelm_test.go`
  - `Test_NewNelmClient`: assert `NewNelmClient` does not override the global nelm logger and `InitDefaultLogger` is idempotent.
  - `Test_NelmLogger_ModuleFromContext`: assert the `module` attribute is emitted only when present in the context.

#### Example

**Before (broken):** nelm client singleton was initialized on first `NewNelmClient` call, freezing `module` to whichever module ran first after pod restart. All subsequent internal nelm messages inherited the wrong module:

```json
{"logger":"addon-operator.module-manager.helm-module.helm-client.nelm","module":"descheduler","msg":"RESOURCE ... STATE WAITING ... AWSMachineClass ..."}
```

Here `descheduler` is frozen — the actual resources (`AWSMachineClass`, `MachineDeployment`) belong to `node-manager` (cloud-instance-manager). The `msg` body is truthful but `module` lies.

**After (fixed):** singleton is initialized once at startup with a neutral logger. Each nelm client method injects the release name as `module` via context, producing correct per-module attribution:

```json
{"logger":"addon-operator.module-manager.helm-module.helm-client.nelm","module":"node-manager","msg":"Running nelm upgrade for release","release_name":"node-manager"}
{"logger":"addon-operator.module-manager.helm-module.helm-client.nelm","module":"kube-dns","msg":"Nelm upgrade successful","release_name":"kube-dns"}
{"logger":"addon-operator.module-manager.helm-module.helm-client.nelm","module":"chrony","msg":"Running nelm upgrade for release","release_name":"chrony"}
```