### PR TITLE
[addon-operator] fix maintenance state tracking in handleUpdateEvent

### DIFF
--- a/pkg/kube_config_manager/kube_config_manager.go
+++ b/pkg/kube_config_manager/kube_config_manager.go
@@ -322,7 +322,7 @@ func (kcm *KubeConfigManager) handleUpdateEvent(moduleName string, cfg *config.M
 
 		if currentCfg.GetMaintenanceState() != cfg.GetMaintenanceState() {
 			changed = true
-			moduleMaintenanceChanged[moduleName] = currentCfg.GetMaintenanceState()
+			moduleMaintenanceChanged[moduleName] = cfg.GetMaintenanceState()
 		}
 	} else {
 		changed = true


### PR DESCRIPTION
## Overview

Fix maintenance state tracking in `handleUpdateEvent` — using new config value (`cfg`) instead of stale cached value (`currentCfg`).

## What this PR does / why we need it

When a user removes `maintenance: NoResourceReconciliation` from a ModuleConfig, the module gets stuck in `Unmanaged` state permanently and never applies configuration changes again.

**Root cause:** `handleUpdateEvent` populates `moduleMaintenanceChanged` map with `currentCfg.GetMaintenanceState()` (old cached state) instead of `cfg.GetMaintenanceState()` (new state from ModuleConfig). This causes the module to apply maintenance state one transition behind:
- Setting maintenance → event carries `Managed` → maintenance never activates
- Removing maintenance → event carries `NoResourceReconciliation` → module goes Unmanaged forever

The batch path (`handleBatchConfigEvent`) and delete path (`handleDeleteEvent`) already use the correct value.

**Steps to reproduce:**
1. Set `maintenance: NoResourceReconciliation` in mc, save
2. Change any parameter in the same mc
3. Remove `maintenance` from mc, save
4. Change any parameter again

**Expected:** after step 3, module is managed again, changes apply.
**Actual:** module enters `Unmanaged`, all changes ignored. Log: `helm release is Unmanaged, skip helm upgrade`

## Special notes for your reviewer

Affects: Deckhouse 1.76 (addon-operator release-1.21)